### PR TITLE
Rename bqutil -> bqext

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,8 +38,8 @@ cache:
 
 script:
 - go test -covermode=count -coverprofile=cloudtest.cov -v github.com/m-lab/go/cloudtest
-- go test -covermode=count -coverprofile=bqutil.cov -v github.com/m-lab/go/bqutil -tags=integration
+- go test -covermode=count -coverprofile=bqext.cov -v github.com/m-lab/go/bqext -tags=integration
 
 # Coveralls
-- $HOME/gopath/bin/gocovmerge cloudtest.cov bqutil.cov > merge.cov
+- $HOME/gopath/bin/gocovmerge cloudtest.cov bqext.cov > merge.cov
 - $HOME/gopath/bin/goveralls -coverprofile=merge.cov -service=travis-ci

--- a/bqext/README.md
+++ b/bqext/README.md
@@ -1,0 +1,6 @@
+# The bqext package
+
+This package contains extensions for the bigquery library, to facilitate
+various common operations, notably query processing.
+
+

--- a/bqext/table.go
+++ b/bqext/table.go
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package bqutil includes generally useful abstractions for simplifying
+// Package bqext includes generally useful abstractions for simplifying
 // interactions with bigquery.
 // Production utilities should go here, but test facilities should go
 // in a separate bqtest package.
 // TODO - rename bqext
-package bqutil
+package bqext
 
 import (
 	"errors"
@@ -30,37 +30,37 @@ import (
 	"google.golang.org/api/option"
 )
 
-// TableExt provides extensions to the bigquery Dataset and Table
+// Table provides extensions to the bigquery Dataset and Table
 // objects to streamline common actions.
 // It encapsulates the Client and Dataset to simplify methods.
 // TODO(gfr) Should this be called DatasetExt ?
-type TableExt struct {
+type Table struct {
 	BqClient *bigquery.Client
 	Dataset  *bigquery.Dataset
 }
 
-// NewTableExt creates a TableExt for a project.
+// NewTable creates a Table for a project.
 // httpClient is used to inject mocks for the bigquery client.
 // if httpClient is nil, a suitable default client is used.
 // Additional bigquery ClientOptions may be optionally passed as final
 //   clientOpts argument.  This is useful for testing credentials.
-func NewTableExt(project, dataset string, clientOpts ...option.ClientOption) (TableExt, error) {
+func NewTable(project, dataset string, clientOpts ...option.ClientOption) (Table, error) {
 	ctx := context.Background()
 	var bqClient *bigquery.Client
 	var err error
 	bqClient, err = bigquery.NewClient(ctx, project, clientOpts...)
 
 	if err != nil {
-		return TableExt{}, err
+		return Table{}, err
 	}
 
-	return TableExt{bqClient, bqClient.Dataset(dataset)}, nil
+	return Table{bqClient, bqClient.Dataset(dataset)}, nil
 }
 
 // ResultQuery constructs a query with common QueryConfig settings for
 // writing results to a table.
 // Generally, may need to change WriteDisposition.
-func (util *TableExt) ResultQuery(query string, dryRun bool) *bigquery.Query {
+func (util *Table) ResultQuery(query string, dryRun bool) *bigquery.Query {
 	q := util.BqClient.Query(query)
 	q.QueryConfig.DryRun = dryRun
 	if strings.HasPrefix(query, "#legacySQL") {
@@ -81,7 +81,7 @@ func (util *TableExt) ResultQuery(query string, dryRun bool) *bigquery.Query {
 // The caller must pass in the *address* of an appropriate struct.
 // TODO - extend this to also handle multirow results, by passing
 // slice of structs.
-func (util *TableExt) QueryAndParse(q string, structPtr interface{}) error {
+func (util *Table) QueryAndParse(q string, structPtr interface{}) error {
 	typeInfo := reflect.ValueOf(structPtr)
 
 	if typeInfo.Type().Kind() != reflect.Ptr {

--- a/bqext/table_integration_test.go
+++ b/bqext/table_integration_test.go
@@ -14,7 +14,7 @@
 
 // +build integration
 
-package bqutil_test
+package bqext_test
 
 // This file contains integration tests, which should be run
 // infrequently, with appropriate credentials.  These tests depend
@@ -30,7 +30,7 @@ import (
 
 	"cloud.google.com/go/bigquery"
 	"github.com/go-test/deep"
-	"github.com/m-lab/go/bqutil"
+	"github.com/m-lab/go/bqext"
 	"golang.org/x/net/context"
 	"google.golang.org/api/option"
 )
@@ -49,7 +49,7 @@ func TestGetTableStats(t *testing.T) {
 		authOpt := option.WithCredentialsFile("../travis-testing.key")
 		opts = append(opts, authOpt)
 	}
-	tExt, err := bqutil.NewTableExt("mlab-testing", "go", opts...)
+	tExt, err := bqext.NewTable("mlab-testing", "go", opts...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -94,7 +94,7 @@ func TestQueryAndParse(t *testing.T) {
 		authOpt := option.WithCredentialsFile("../travis-testing.key")
 		opts = append(opts, authOpt)
 	}
-	tExt, err := bqutil.NewTableExt("mlab-testing", "go", opts...)
+	tExt, err := bqext.NewTable("mlab-testing", "go", opts...)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/bqext/table_test.go
+++ b/bqext/table_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package bqutil_test
+package bqext_test
 
 import (
 	"bytes"
@@ -26,7 +26,7 @@ import (
 
 	"cloud.google.com/go/bigquery"
 	"github.com/go-test/deep"
-	"github.com/m-lab/go/bqutil"
+	"github.com/m-lab/go/bqext"
 	"github.com/m-lab/go/cloudtest"
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2/google"
@@ -84,7 +84,7 @@ func getTableStatsClient() *http.Client {
 // can be found it that test's output.
 func TestGetTableStatsMock(t *testing.T) {
 	opts := []option.ClientOption{option.WithHTTPClient(getTableStatsClient())}
-	tExt, err := bqutil.NewTableExt("mock", "mock", opts...)
+	tExt, err := bqext.NewTable("mock", "mock", opts...)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/bqutil/README.md
+++ b/bqutil/README.md
@@ -1,6 +1,0 @@
-# The bqutil package
-
-This package contains utilities that facilitate various bigquery
-operations, notably query processing.
-
-


### PR DESCRIPTION
Followup to rename bqutil to bqext, and TableUtil to Table, to improve readability.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/go/6)
<!-- Reviewable:end -->
