### PR TITLE
More bigquery Dataset extensions for dedupping

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,9 @@ before_install:
 
 - echo Branch is ${TRAVIS_BRANCH} and Tag is $TRAVIS_TAG
 
+- echo EVENT_TYPE is ${TRAVIS_EVENT_TYPE}
 - if ${TRAVIS_EVENT_TYPE} == cron; then TEST_TAGS=integration; fi;
+- echo TEST_TAGS is ${TEST_TAGS}
 
 # These directories will be cached on successful "script" builds, and restored,
 # if available, to save time on future builds.

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_install:
 - echo Branch is ${TRAVIS_BRANCH} and Tag is $TRAVIS_TAG
 
 - echo EVENT_TYPE is ${TRAVIS_EVENT_TYPE}
-- if ${TRAVIS_EVENT_TYPE} == cron; then TEST_TAGS=integration; fi;
+- if [[ ${TRAVIS_EVENT_TYPE} == cron ]]; then TEST_TAGS=integration; fi;
 - echo TEST_TAGS is ${TEST_TAGS}
 
 # These directories will be cached on successful "script" builds, and restored,

--- a/bqext/dataset.go
+++ b/bqext/dataset.go
@@ -112,17 +112,6 @@ func (dsExt *Dataset) QueryAndParse(q string, structPtr interface{}) error {
 	return nil
 }
 
-// TableInfo contains the critical stats for a specific table
-// or partition.
-type TableInfo struct {
-	Name             string
-	IsPartitioned    bool
-	NumBytes         int64
-	NumRows          uint64
-	CreationTime     time.Time
-	LastModifiedTime time.Time
-}
-
 // PartitionInfo provides basic information about a partition.
 type PartitionInfo struct {
 	PartitionID  string

--- a/bqext/dataset.go
+++ b/bqext/dataset.go
@@ -36,8 +36,8 @@ import (
 // objects to streamline common actions.
 // It encapsulates the Client and Dataset to simplify methods.
 type Dataset struct {
-	BqClient *bigquery.Client
-	Dataset  *bigquery.Dataset
+	*bigquery.Dataset // Exposes Dataset API directly.
+	BqClient          *bigquery.Client
 }
 
 // NewDataset creates a Dataset for a project.
@@ -55,7 +55,7 @@ func NewDataset(project, dataset string, clientOpts ...option.ClientOption) (Dat
 		return Dataset{}, err
 	}
 
-	return Dataset{bqClient, bqClient.Dataset(dataset)}, nil
+	return Dataset{bqClient.Dataset(dataset), bqClient}, nil
 }
 
 // ResultQuery constructs a query with common QueryConfig settings for
@@ -68,8 +68,8 @@ func (dsExt *Dataset) ResultQuery(query string, dryRun bool) *bigquery.Query {
 		q.QueryConfig.UseLegacySQL = true
 	}
 	// Default for unqualified table names in the query.
-	q.QueryConfig.DefaultProjectID = dsExt.Dataset.ProjectID
-	q.QueryConfig.DefaultDatasetID = dsExt.Dataset.DatasetID
+	q.QueryConfig.DefaultProjectID = dsExt.ProjectID
+	q.QueryConfig.DefaultDatasetID = dsExt.DatasetID
 	return q
 }
 
@@ -155,8 +155,8 @@ func (dsExt *Dataset) DestinationQuery(query string, dest *bigquery.Table, dispo
 	q.QueryConfig.WriteDisposition = disposition
 	q.QueryConfig.AllowLargeResults = true
 	// Default for unqualified table names in the query.
-	q.QueryConfig.DefaultProjectID = dsExt.Dataset.ProjectID
-	q.QueryConfig.DefaultDatasetID = dsExt.Dataset.DatasetID
+	q.QueryConfig.DefaultProjectID = dsExt.ProjectID
+	q.QueryConfig.DefaultDatasetID = dsExt.DatasetID
 	q.QueryConfig.DisableFlattenedResults = true
 	return q
 }

--- a/bqext/dataset.go
+++ b/bqext/dataset.go
@@ -20,8 +20,11 @@ package bqext
 
 import (
 	"errors"
+	"fmt"
+	"log"
 	"reflect"
 	"strings"
+	"time"
 
 	"cloud.google.com/go/bigquery"
 	"golang.org/x/net/context"
@@ -107,4 +110,107 @@ func (dsExt *Dataset) QueryAndParse(q string, structPtr interface{}) error {
 		return errors.New("multiple row data")
 	}
 	return nil
+}
+
+// TableInfo contains the critical stats for a specific table
+// or partition.
+type TableInfo struct {
+	Name             string
+	IsPartitioned    bool
+	NumBytes         int64
+	NumRows          uint64
+	CreationTime     time.Time
+	LastModifiedTime time.Time
+}
+
+// PartitionInfo provides basic information about a partition.
+type PartitionInfo struct {
+	PartitionID  string
+	CreationTime time.Time
+	LastModified time.Time
+}
+
+// GetPartitionInfo provides basic information about a partition.
+func (dsExt Dataset) GetPartitionInfo(table string, partition string) (PartitionInfo, error) {
+	// This uses legacy, because PARTITION_SUMMARY is not supported in standard.
+	queryString := fmt.Sprintf(
+		`#legacySQL
+		SELECT
+		  partition_id as PartitionID,
+		  msec_to_timestamp(creation_time) AS CreationTime,
+		  msec_to_timestamp(last_modified_time) AS LastModified
+		FROM
+		  [%s$__PARTITIONS_SUMMARY__]
+		where partition_id = "%s" `, table, partition)
+	pi := PartitionInfo{}
+
+	err := dsExt.QueryAndParse(queryString, &pi)
+	if err != nil {
+		log.Println(err)
+		return PartitionInfo{}, err
+	}
+	return pi, nil
+}
+
+// DestinationQuery constructs a query with common Config settings for
+// writing results to a table.
+// Generally, may need to change WriteDisposition.
+func (dsExt *Dataset) DestinationQuery(query string, dest *bigquery.Table) *bigquery.Query {
+	q := dsExt.BqClient.Query(query)
+	if dest != nil {
+		q.QueryConfig.Dst = dest
+	} else {
+		q.QueryConfig.DryRun = true
+	}
+	q.QueryConfig.AllowLargeResults = true
+	// Default for unqualified table names in the query.
+	q.QueryConfig.DefaultProjectID = dsExt.Dataset.ProjectID
+	q.QueryConfig.DefaultDatasetID = dsExt.Dataset.DatasetID
+	q.QueryConfig.DisableFlattenedResults = true
+	return q
+}
+
+///////////////////////////////////////////////////////////////////
+// Specific queries.
+///////////////////////////////////////////////////////////////////
+
+// TODO - really should take the one that was parsed last, instead
+// of random
+var dedupTemplate = `
+	#standardSQL
+	# Delete all duplicate rows based on test_id
+	SELECT * except (row_number)
+	FROM (
+	  SELECT *, ROW_NUMBER() OVER (PARTITION BY %s) row_number
+	  FROM ` + "`%s`" + `)
+	WHERE row_number = 1`
+
+// Dedup executes a query that dedups and writes to an appropriate
+// partition.
+// src is relative to the project:dataset of dsExt.
+// dedupOn names the field to be used for dedupping.
+// project, dataset, table specify the table to write into.
+// NOTE: destination table must include the partition suffix.  This
+// avoids accidentally overwriting TODAY's partition.
+func (dsExt *Dataset) Dedup(src string, dedupOn string, overwrite bool, project, dataset, table string) (*bigquery.JobStatus, error) {
+	if !strings.Contains(table, "$") {
+		return nil, errors.New("Destination table does not specify partition")
+	}
+	queryString := fmt.Sprintf(dedupTemplate, dedupOn, src)
+	dest := dsExt.BqClient.DatasetInProject(project, dataset)
+	q := dsExt.DestinationQuery(queryString, dest.Table(table))
+	if overwrite {
+		q.QueryConfig.WriteDisposition = bigquery.WriteTruncate
+	}
+	log.Printf("Removing dups (of %s) and writing to %s\n", dedupOn, table)
+	job, err := q.Run(context.Background())
+	if err != nil {
+		return nil, err
+	}
+	log.Println("JobID:", job.ID())
+	status, err := job.Wait(context.Background())
+	if err != nil {
+		return status, err
+	}
+	return status, nil
 }

--- a/bqext/dataset.go
+++ b/bqext/dataset.go
@@ -135,7 +135,7 @@ func (dsExt Dataset) GetPartitionInfo(table string, partition string) (Partition
 
 	err := dsExt.QueryAndParse(queryString, &pi)
 	if err != nil {
-		log.Println(err)
+		log.Println(err, ":", queryString)
 		return PartitionInfo{}, err
 	}
 	return pi, nil

--- a/bqext/dataset_integration_test.go
+++ b/bqext/dataset_integration_test.go
@@ -27,6 +27,7 @@ import (
 	"log"
 	"os"
 	"testing"
+	"time"
 
 	"cloud.google.com/go/bigquery"
 	"github.com/go-test/deep"
@@ -129,5 +130,67 @@ func TestQueryAndParse(t *testing.T) {
 	}
 	if pi.PartitionID != "20170101" {
 		t.Error("Incorrect PartitionID")
+	}
+}
+
+func ClientOpts() []option.ClientOption {
+	opts := []option.ClientOption{}
+	if os.Getenv("TRAVIS") != "" {
+		authOpt := option.WithCredentialsFile("../travis-testing.key")
+		opts = append(opts, authOpt)
+	}
+	return opts
+}
+
+func TestDedup(t *testing.T) {
+	start := time.Now() // Later, we will compare partition time to this.
+
+	tExt, err := bqext.NewDataset("mlab-testing", "etl", ClientOpts()...)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// First check that source table has expected number of rows.
+	// TestDedupSrc should have 6 rows, of which 4 should be unique.
+	type QR struct {
+		NumRows int64
+	}
+	result := QR{}
+	err = tExt.QueryAndParse("select count(test_id) as NumRows from `TestDedupSrc_19990101`", &result)
+	if result.NumRows != 6 {
+		t.Fatal("Source table has wrong number rows: ", result.NumRows)
+	}
+
+	_, err = tExt.Dedup("TestDedupSrc_19990101", "test_id", true, "mlab-testing", "etl", "TestDedupDest$19990101")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pi, err := tExt.GetPartitionInfo("TestDedupDest", "19990101")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pi.CreationTime.Before(start) {
+		t.Error("Partition not overwritten??? ", pi.CreationTime)
+	}
+
+	err = tExt.QueryAndParse("select count(test_id) as NumRows from `TestDedupDest` where _PARTITIONTIME = timestamp("+`"1999-01-01 00:00:00"`+")", &result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.NumRows != 4 {
+		t.Error("Destination has wrong number of rows: ", result.NumRows)
+	}
+}
+
+func TestPartitionInfo(t *testing.T) {
+	util, err := bqext.NewDataset("mlab-testing", "etl", ClientOpts()...)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := util.GetPartitionInfo("TestDedupDest", "19990101")
+	if info.PartitionID != "19990101" {
+		t.Error("Incorrect PartitionID", info)
 	}
 }

--- a/bqext/dataset_integration_test.go
+++ b/bqext/dataset_integration_test.go
@@ -21,6 +21,8 @@ package bqext_test
 // on the state of our bigquery tables, so they may start failing
 // if the tables are changed.
 
+// TODO (issue #8) tests that use bq tables should create them from scratch.
+
 import (
 	"encoding/json"
 	"fmt"
@@ -80,10 +82,12 @@ func TestGetTableStats(t *testing.T) {
 }
 
 // PartitionInfo provides basic information about a partition.
+// Note that a similar struct is defined in dataset.go, but this
+// one is used for testing the QueryAndParse method.
 type PartitionInfo struct {
-	PartitionID string `qfield:"partition_id"`
-	//	CreationTime time.Time `qfield:"created"`
-	//	LastModified time.Time `qfield:"last_modified"`
+	PartitionID  string
+	CreationTime time.Time
+	LastModified time.Time
 }
 
 func TestQueryAndParse(t *testing.T) {

--- a/bqext/dataset_integration_test.go
+++ b/bqext/dataset_integration_test.go
@@ -148,7 +148,7 @@ func clientOpts() []option.ClientOption {
 
 // TODO - should build the test tables from scratch.  See https://github.com/m-lab/go/issues/8
 
-func TestDedup(t *testing.T) {
+func TestDedup_Alpha(t *testing.T) {
 	start := time.Now() // Later, we will compare partition time to this.
 
 	tExt, err := bqext.NewDataset("mlab-testing", "etl", clientOpts()...)
@@ -167,7 +167,8 @@ func TestDedup(t *testing.T) {
 		t.Fatal("Source table has wrong number rows: ", result.NumRows)
 	}
 
-	_, err = tExt.Dedup("TestDedupSrc_19990101", "test_id", true, "mlab-testing", "etl", "TestDedupDest$19990101")
+	destTable := tExt.BqClient.DatasetInProject("mlab-testing", "etl").Table("TestDedupDest$19990101")
+	_, err = tExt.Dedup_Alpha("TestDedupSrc_19990101", "test_id", destTable)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/bqext/dataset_integration_test.go
+++ b/bqext/dataset_integration_test.go
@@ -81,10 +81,10 @@ func TestGetTableStats(t *testing.T) {
 	}
 }
 
-// PartitionInfo provides basic information about a partition.
+// partitionInfo provides basic information about a partition.
 // Note that a similar struct is defined in dataset.go, but this
 // one is used for testing the QueryAndParse method.
-type PartitionInfo struct {
+type partitionInfo struct {
 	PartitionID  string
 	CreationTime time.Time
 	LastModified time.Time
@@ -114,10 +114,10 @@ func TestQueryAndParse(t *testing.T) {
 		FROM
 		  [%s$__PARTITIONS_SUMMARY__]
 		where partition_id = "%s" `, "TestQueryAndParse", "20170101")
-	pi := PartitionInfo{}
+	pi := partitionInfo{}
 
 	// Should be simple struct...
-	err = tExt.QueryAndParse(queryString, []PartitionInfo{})
+	err = tExt.QueryAndParse(queryString, []partitionInfo{})
 	if err == nil {
 		t.Error("Should produce error on slice input")
 	}
@@ -137,7 +137,7 @@ func TestQueryAndParse(t *testing.T) {
 	}
 }
 
-func ClientOpts() []option.ClientOption {
+func clientOpts() []option.ClientOption {
 	opts := []option.ClientOption{}
 	if os.Getenv("TRAVIS") != "" {
 		authOpt := option.WithCredentialsFile("../travis-testing.key")
@@ -146,10 +146,12 @@ func ClientOpts() []option.ClientOption {
 	return opts
 }
 
+// TODO - should build the test tables from scratch.  See https://github.com/m-lab/go/issues/8
+
 func TestDedup(t *testing.T) {
 	start := time.Now() // Later, we will compare partition time to this.
 
-	tExt, err := bqext.NewDataset("mlab-testing", "etl", ClientOpts()...)
+	tExt, err := bqext.NewDataset("mlab-testing", "etl", clientOpts()...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -188,7 +190,7 @@ func TestDedup(t *testing.T) {
 }
 
 func TestPartitionInfo(t *testing.T) {
-	util, err := bqext.NewDataset("mlab-testing", "etl", ClientOpts()...)
+	util, err := bqext.NewDataset("mlab-testing", "etl", clientOpts()...)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/bqext/dataset_integration_test.go
+++ b/bqext/dataset_integration_test.go
@@ -57,7 +57,7 @@ func TestGetTableStats(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	table := tExt.Dataset.Table("TestGetTableStats")
+	table := tExt.Table("TestGetTableStats")
 	ctx := context.Background()
 	stats, err := table.Metadata(ctx)
 	if err != nil {

--- a/bqext/dataset_test.go
+++ b/bqext/dataset_test.go
@@ -130,7 +130,7 @@ func TestResultQuery(t *testing.T) {
 
 // This test only check very basic stuff.  Intended mostly just to
 // improve coverage metrics.
-func TestDestinationQuery(t *testing.T) {
+func TestDestQuery(t *testing.T) {
 	// Create a dummy client.
 	opts := []option.ClientOption{option.WithHTTPClient(getOKClient())}
 	dsExt, err := bqext.NewDataset("mock", "mock", opts...)
@@ -138,7 +138,7 @@ func TestDestinationQuery(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	q := dsExt.DestinationQuery("query string", nil, bigquery.WriteEmpty)
+	q := dsExt.DestQuery("query string", nil, bigquery.WriteEmpty)
 	qc := q.QueryConfig
 	if qc.Dst != nil {
 		t.Error("Destination should be nil.")
@@ -147,7 +147,7 @@ func TestDestinationQuery(t *testing.T) {
 		t.Error("DryRun should be set.")
 	}
 
-	q = dsExt.DestinationQuery("query string", dsExt.Table("foobar"), bigquery.WriteEmpty)
+	q = dsExt.DestQuery("query string", dsExt.Table("foobar"), bigquery.WriteEmpty)
 	qc = q.QueryConfig
 	if qc.Dst.TableID != "foobar" {
 		t.Error("Destination should be foobar.")

--- a/bqext/dataset_test.go
+++ b/bqext/dataset_test.go
@@ -138,7 +138,7 @@ func TestDestinationQuery(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	q := dsExt.DestinationQuery("query string", nil)
+	q := dsExt.DestinationQuery("query string", nil, bigquery.WriteEmpty)
 	qc := q.QueryConfig
 	if qc.Dst != nil {
 		t.Error("Destination should be nil.")
@@ -147,7 +147,7 @@ func TestDestinationQuery(t *testing.T) {
 		t.Error("DryRun should be set.")
 	}
 
-	q = dsExt.DestinationQuery("query string", dsExt.Dataset.Table("foobar"))
+	q = dsExt.DestinationQuery("query string", dsExt.Dataset.Table("foobar"), bigquery.WriteEmpty)
 	qc = q.QueryConfig
 	if qc.Dst.TableID != "foobar" {
 		t.Error("Destination should be foobar.")

--- a/bqext/dataset_test.go
+++ b/bqext/dataset_test.go
@@ -126,15 +126,13 @@ func TestResultQuery(t *testing.T) {
 	if qc.DryRun {
 		t.Error("DryRun should be false.")
 	}
-
 }
 
 // This test only check very basic stuff.  Intended mostly just to
 // improve coverage metrics.
 func TestDestinationQuery(t *testing.T) {
 	// Create a dummy client.
-	client := cloudtest.NewChannelClient(make(chan *http.Response, 10))
-	opts := []option.ClientOption{option.WithHTTPClient(client)}
+	opts := []option.ClientOption{option.WithHTTPClient(getOKClient())}
 	dsExt, err := bqext.NewDataset("mock", "mock", opts...)
 	if err != nil {
 		t.Fatal(err)
@@ -157,5 +155,4 @@ func TestDestinationQuery(t *testing.T) {
 	if qc.DryRun {
 		t.Error("DryRun should be false.")
 	}
-
 }

--- a/bqext/dataset_test.go
+++ b/bqext/dataset_test.go
@@ -88,7 +88,7 @@ func TestGetTableStatsMock(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	table := dsExt.Dataset.Table("TestGetTableStats")
+	table := dsExt.Table("TestGetTableStats")
 	ctx := context.Background()
 	stats, err := table.Metadata(ctx)
 	if err != nil {
@@ -147,7 +147,7 @@ func TestDestinationQuery(t *testing.T) {
 		t.Error("DryRun should be set.")
 	}
 
-	q = dsExt.DestinationQuery("query string", dsExt.Dataset.Table("foobar"), bigquery.WriteEmpty)
+	q = dsExt.DestinationQuery("query string", dsExt.Table("foobar"), bigquery.WriteEmpty)
 	qc = q.QueryConfig
 	if qc.Dst.TableID != "foobar" {
 		t.Error("Destination should be foobar.")


### PR DESCRIPTION
Adds DestinationQuery() and Dedup()

This was previously reviewed as https://github.com/m-lab/etl/pull/360, but based on feedback decided to move it to the m-lab/go repo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/go/10)
<!-- Reviewable:end -->
