### PR TITLE
Copy code of general utility out from pusher.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "travis"]
 	path = travis
 	url = ../travis
+[submodule "git-hooks"]
+	path = git-hooks
+	url = https://github.com/m-lab/git-hooks.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,12 +38,21 @@ before_install:
 # if available, to save time on future builds.
 cache:
   directories:
-    - "$HOME/google-cloud-sdk/"
+  - "$HOME/google-cloud-sdk/"
 
 script:
-- go test -covermode=count -coverprofile=cloudtest.cov -v github.com/m-lab/go/cloudtest
-- go test -covermode=count -coverprofile=bqext.cov -v github.com/m-lab/go/bqext -tags=$TEST_TAGS
+# This script replaces / with ___ in the coverage file names. If you have
+# two modules, one named x/y and one named x___y, then this will break. But
+# don't put triple underscores in a module name: That's bad practice anyway.
+- for module in $(find * -type d |
+                  grep -v '^git-hooks$' |
+                  grep -v '^travis$'); do
+    go test -v -covermode=count -coverprofile=${module#/#___}.cov ./$module ;
+  done
+# bqext should also have its integration tests run.
+- go test -covermode=count -coverprofile=_bqext.cov -v ./bqext -tags=$TEST_TAGS
 
 # Coveralls
-- $HOME/gopath/bin/gocovmerge cloudtest.cov bqext.cov > merge.cov
-- $HOME/gopath/bin/goveralls -coverprofile=merge.cov -service=travis-ci
+# This will fail if you name a module ___merge, so don't do that.
+- $HOME/gopath/bin/gocovmerge *.cov > ___merge.cov
+- $HOME/gopath/bin/goveralls -coverprofile=___merge.cov -service=travis-ci

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # go
-| branch | travis-ci | coveralls |
-|--------|-----------|-----------|
-| master | [![Travis Build Status](https://travis-ci.org/m-lab/go.svg?branch=master)](https://travis-ci.org/m-lab/go) | [![Coverage Status](https://coveralls.io/repos/m-lab/go/badge.svg?branch=master)](https://coveralls.io/github/m-lab/go?branch=master) |
+| branch | travis-ci | coveralls | docs | report card |
+|--------|-----------|-----------|------|-------------|
+| master | [![Travis Build Status](https://travis-ci.org/m-lab/go.svg?branch=master)](https://travis-ci.org/m-lab/go) | [![Coverage Status](https://coveralls.io/repos/m-lab/go/badge.svg?branch=master)](https://coveralls.io/github/m-lab/go?branch=master) | [![GoDoc](https://godoc.org/github.com/m-lab/go?status.svg)](https://godoc.org/github.com/m-lab/go) | [![Go Report Card](https://goreportcard.com/badge/github.com/m-lab/go)](https://goreportcard.com/report/github.com/m-lab/go)
 
 [![Waffle.io](https://badge.waffle.io/m-lab/go.svg?title=Ready)](http://waffle.io/m-lab/go)
 
@@ -34,8 +34,18 @@ as *alpha* or *beta* until they are regarded as stable and suitable for
 general use.
 
 ## packages
+### bqext
+Utilities for interacting with BigQuery
+
+### bytecount
+Allows commandline flags to express quantities of Bytes like `--size=20MB`
+
 ### cloudtest
 Utilities for testing google cloud service abstractions.
 
-### bqutil
-Utilities for interacting with BigQuery
+### flagext
+Extensions for the flag library
+
+### runtimeext
+Functions of general utility
+

--- a/bytecount/README.md
+++ b/bytecount/README.md
@@ -1,0 +1,3 @@
+A datatype to hold counts of bytes.
+
+Useful for setting byte counts as command-line arguments

--- a/bytecount/bytes.go
+++ b/bytecount/bytes.go
@@ -1,0 +1,89 @@
+// Package bytecount provides a single datatype ByteCount, designed to track
+// counts of bytes, as well as some helper constants.  It also provides all the
+// necessary functions to allow a ByteCount to be specified as a command-line
+// argument, which should allow command-line arguments like
+// `--cache-size=20MB`.
+package bytecount
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strconv"
+
+	r "github.com/m-lab/go/runtimeext"
+)
+
+// ByteCount holds filesizes and the like.
+type ByteCount int64
+
+// Some constants to make working with ByteCounts easier.  If the difference
+// between Kilobytes and Kibibytes matters to you, then this library is likely
+// too unsophisticated for your needs.  Pull requests are welcome, however.
+const (
+	Byte     ByteCount = 1
+	Kilobyte           = 1000 * Byte
+	Megabyte           = 1000 * Kilobyte
+	Gigabyte           = 1000 * Megabyte
+)
+
+// Get is used by the Flag library to get the value out of the ByteCount.
+func (b ByteCount) Get() interface{} {
+	return b
+}
+
+// String is used by the Flag library to turn the value into a string.  Because
+// we output bytecounts in our logs, it is worth it to convert them into
+// readable values.
+func (b ByteCount) String() string {
+	if b%Gigabyte == 0 {
+		return fmt.Sprintf("%dGB", b/Gigabyte)
+	} else if b%Megabyte == 0 {
+		return fmt.Sprintf("%dMB", b/Megabyte)
+	} else if b%Kilobyte == 0 {
+		return fmt.Sprintf("%dKB", b/Kilobyte)
+	}
+	return fmt.Sprintf("%dB", b)
+}
+
+// Set is used by the Flag library to turn a string into a ByteCount.  This
+// implementation parses on the quick and dirty using regular expressions.
+func (b *ByteCount) Set(s string) error {
+	bytesRegexpStr := `^(?P<quantity>[0-9]+)(?P<units>[KMG]?B?)?$`
+	bytesRegexp := regexp.MustCompile(bytesRegexpStr)
+	if !bytesRegexp.MatchString(s) {
+		return fmt.Errorf("Invalid size format: %q", s)
+	}
+	for _, submatches := range bytesRegexp.FindAllStringSubmatchIndex(s, -1) {
+		quantityBytes := bytesRegexp.ExpandString([]byte{}, "$quantity", s, submatches)
+		quantityInt, err := strconv.ParseInt(string(quantityBytes), 10, 64)
+		// If this check ever fails, it represents a bug in the code rather than a
+		// normal response to bad input. A richer compiler would be able to prove
+		// that this check always passes. Regrettably, that compiler does not exist.
+		r.Must(err, "The string %q passed the regexp %q but did not have an int we could parse. This is a bug.", s, bytesRegexpStr)
+		quantity := ByteCount(quantityInt)
+		unitsBytes := bytesRegexp.ExpandString([]byte{}, "$units", s, submatches)
+		units := Byte
+		err = errors.New("No units found")
+		switch string(unitsBytes) {
+		case "B", "":
+			units = Byte
+			err = nil
+		case "KB", "K":
+			units = Kilobyte
+			err = nil
+		case "MB", "M":
+			units = Megabyte
+			err = nil
+		case "GB", "G":
+			units = Gigabyte
+			err = nil
+		}
+		// If this check ever fails, it represents a bug in the code rather than a
+		// normal response to bad input. A richer compiler would be able to prove
+		// that this check always passes. Regrettably, that compiler does not exist.
+		r.Must(err, "The string %q passed the regexp %q but did not have units we could parse. This is a bug.", s, bytesRegexpStr)
+		*b = quantity * units
+	}
+	return nil
+}

--- a/bytecount/bytes_test.go
+++ b/bytecount/bytes_test.go
@@ -1,0 +1,69 @@
+package bytecount
+
+import (
+	"flag"
+	"testing"
+)
+
+func TestByteParsing(t *testing.T) {
+	// Check successes
+	tests := []struct {
+		in  string
+		out ByteCount
+	}{
+		{in: "1KB", out: ByteCount(1000)},
+		{in: "1B", out: ByteCount(1)},
+		{in: "2KB", out: ByteCount(2000)},
+		{in: "3MB", out: ByteCount(3000000)},
+		{in: "4GB", out: ByteCount(4000000000)},
+		{in: "5K", out: ByteCount(5000)},
+		{in: "6M", out: ByteCount(6000000)},
+		{in: "7G", out: ByteCount(7000000000)},
+		{in: "1000", out: ByteCount(1000)},
+		{in: "2", out: ByteCount(2)},
+	}
+	for _, test := range tests {
+		b := ByteCount(0)
+		if err := b.Set(test.in); err != nil {
+			t.Error(err)
+		}
+		if b.Get().(ByteCount) != test.out {
+			t.Errorf("Bad parse of %s (%d bytes != %d bytes)", test.in, test.out, b.Get().(ByteCount))
+		}
+	}
+	// Check failures
+	for _, input := range []string{"1 K", "1KB4BG", "K", "-3K", "abc12KB", "12KBabc"} {
+		b := ByteCount(0)
+		if err := b.Set(input); err == nil {
+			t.Errorf("Failed to have an error on %q", input)
+		}
+	}
+}
+
+func TestString(t *testing.T) {
+	tests := []struct {
+		in  ByteCount
+		out string
+	}{
+		{out: "1B", in: ByteCount(1 * Byte)},
+		{out: "2KB", in: ByteCount(2 * Kilobyte)},
+		{out: "3MB", in: ByteCount(3 * Megabyte)},
+		{out: "4GB", in: ByteCount(4 * Gigabyte)},
+		{out: "5B", in: ByteCount(5)},
+		{out: "6KB", in: ByteCount(6000)},
+		{out: "7MB", in: ByteCount(7000000)},
+		{out: "8GB", in: ByteCount(8000000000)},
+	}
+	for _, test := range tests {
+		if test.in.String() != test.out {
+			t.Errorf("Bytecount(%d).String() returned should have returned %s (actually returned %q)", test.in, test.out, test.in.String())
+		}
+	}
+}
+
+// Successful compilation of this function means that ByteCount implements the
+// flag.Getter interface.
+func assertFlagGetter(in flag.Getter) {
+	var b ByteCount
+	func(in flag.Getter) {}(&b)
+}

--- a/flagext/README.md
+++ b/flagext/README.md
@@ -1,0 +1,1 @@
+Functions which extend the capabilities of the `flag` library.

--- a/flagext/argsfromenv.go
+++ b/flagext/argsfromenv.go
@@ -1,0 +1,41 @@
+// Package flagext extends to capabilities of flags to also be able to read
+// from environment variables.  This comes in handy when dockerizing
+// applications.
+package flagext
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+)
+
+// ArgsFromEnv will expand command-line argument parsing to include setting the
+// values of flags from their corresponding environment variables. The
+// environment variable for an argument is the upper-case version of the
+// command-line flag.
+func ArgsFromEnv(flagSet *flag.FlagSet) error {
+	// Allow environment variables to be used for unspecified commandline flags.
+	// Track what flags were explicitly set so that we won't override those flags.
+	specifiedFlags := make(map[string]struct{})
+	flagSet.Visit(func(f *flag.Flag) { specifiedFlags[f.Name] = struct{}{} })
+
+	// All flags that were not explicitly set but do have a corresponding evironment variable should be set to that env value.
+	// Visit every flag and don't override explicitly set commandline args.
+	var err error
+	flagSet.VisitAll(func(f *flag.Flag) {
+		envVarName := strings.ToUpper(f.Name)
+		if val, ok := os.LookupEnv(envVarName); ok {
+			if _, specified := specifiedFlags[f.Name]; specified {
+				log.Printf("WARNING: Not overriding flag -%s=%q with evironment variable %s=%q\n", f.Name, f.Value, envVarName, val)
+			} else {
+				if setErr := f.Value.Set(val); setErr != nil {
+					err = fmt.Errorf("Could not set argument %s to the value of environment variable %s=%q (err: %s)", f.Name, envVarName, val, setErr)
+				}
+			}
+		}
+		log.Printf("Argument %s=%v\n", f.Name, f.Value)
+	})
+	return err
+}

--- a/flagext/argsfromenv_test.go
+++ b/flagext/argsfromenv_test.go
@@ -1,0 +1,97 @@
+package flagext_test
+
+import (
+	"flag"
+	"log"
+	"os"
+	"testing"
+
+	flagx "github.com/m-lab/go/flagext"
+)
+
+func TestArgsFromEnvDefaults(t *testing.T) {
+	flagSet := flag.NewFlagSet("test_flags", flag.ContinueOnError)
+	flagVal := flagSet.String("pusher_util_test_var", "default", "")
+	flagSet.Parse([]string{})
+	if err := flagx.ArgsFromEnv(flagSet); err != nil {
+		t.Error(err)
+	}
+	if *flagVal != "default" {
+		t.Error("Bad flag value", *flagVal)
+	}
+}
+
+func TestArgsFromEnvSpecifiedNoEnv(t *testing.T) {
+	flagSet := flag.NewFlagSet("test_flags", flag.ContinueOnError)
+	flagVal := flagSet.String("pusher_util_test_var", "default", "")
+	flagSet.Parse([]string{"-pusher_util_test_var=value_from_cmdline"})
+	if err := flagx.ArgsFromEnv(flagSet); err != nil {
+		t.Error(err)
+	}
+	if *flagVal != "value_from_cmdline" {
+		t.Error("Bad flag value", *flagVal)
+	}
+}
+
+func TestArgsFromEnvNotSpecifiedYesEnv(t *testing.T) {
+	flagSet := flag.NewFlagSet("test_flags", flag.ContinueOnError)
+	flagVal := flagSet.String("pusher_util_test_var", "default", "")
+	oldVal, ok := os.LookupEnv("PUSHER_UTIL_TEST_VAR")
+	os.Setenv("PUSHER_UTIL_TEST_VAR", "value_from_env")
+	defer func() {
+		if ok {
+			os.Setenv("PUSHER_UTIL_TEST_VAR", oldVal)
+		} else {
+			os.Unsetenv("PUSHER_UTIL_TEST_VAR")
+		}
+	}()
+	flagSet.Parse([]string{})
+	if err := flagx.ArgsFromEnv(flagSet); err != nil {
+		t.Error(err)
+	}
+	if *flagVal != "value_from_env" {
+		t.Error("Bad flag value", *flagVal)
+	}
+}
+
+func TestArgsFromEnvWontOverride(t *testing.T) {
+	flagSet := flag.NewFlagSet("test_flags", flag.ContinueOnError)
+	flagVal := flagSet.String("pusher_util_test_var", "default", "")
+	oldVal, ok := os.LookupEnv("PUSHER_UTIL_TEST_VAR")
+	os.Setenv("PUSHER_UTIL_TEST_VAR", "value_from_env")
+	defer func() {
+		if ok {
+			os.Setenv("PUSHER_UTIL_TEST_VAR", oldVal)
+		} else {
+			os.Unsetenv("PUSHER_UTIL_TEST_VAR")
+		}
+	}()
+	flagSet.Parse([]string{"-pusher_util_test_var=value_from_cmdline"})
+	if err := flagx.ArgsFromEnv(flagSet); err != nil {
+		t.Error(err)
+	}
+	if *flagVal != "value_from_cmdline" {
+		t.Error("Bad flag value", *flagVal)
+	}
+}
+
+func TestArgsFromEnvWithBadEnv(t *testing.T) {
+	flagSet := flag.NewFlagSet("test_flags", flag.ContinueOnError)
+	flagVal := flagSet.Int("pusher_util_test_var", 1, "")
+	oldVal, ok := os.LookupEnv("PUSHER_UTIL_TEST_VAR")
+	os.Setenv("PUSHER_UTIL_TEST_VAR", "bad_value_from_env")
+	defer func() {
+		if ok {
+			os.Setenv("PUSHER_UTIL_TEST_VAR", oldVal)
+		} else {
+			os.Unsetenv("PUSHER_UTIL_TEST_VAR")
+		}
+	}()
+	flagSet.Parse([]string{""})
+	err := flagx.ArgsFromEnv(flagSet)
+	if err == nil {
+		t.Error("Should have had an error")
+	} else {
+		log.Printf("After an invalid Set() (err=%q), the flag is %d\n", err, *flagVal)
+	}
+}

--- a/runtimeext/README.md
+++ b/runtimeext/README.md
@@ -1,0 +1,6 @@
+Functions that maybe should be part of the standard go runtime.
+
+Contains a function `Must` that calls `log.Fatal` if its first argument is not a
+nil error and prints out a nice error message otherwise.  Using `Must` aids in
+the pursuit of 100% code coverage, because it means that the error pathway of
+`log.Fatal` is in this library instead of inline with the code being tested.

--- a/runtimeext/must.go
+++ b/runtimeext/must.go
@@ -1,0 +1,36 @@
+// Package runtimeext provides free functions that would be handy to have as
+// part of the go standard runtime.
+package runtimeext
+
+import (
+	"fmt"
+	"log"
+)
+
+// Allow overriding of this variable to aid in whitebox testing.
+var logFatal = log.Fatal
+
+// Must will call log.Fatal if passed a non-nil error. The fatal message is
+// specified as the prefix argument. If any further args are passed, then the
+// prefix will be treated as a format string.
+//
+// The main purpose of this function is to turn the common pattern of:
+//    err := Func()
+//    if err != nil {
+//        log.Fatalf("Helpful message (error: %v)", err)
+//    }
+// into a simplified pattern of:
+//    Must(Func(), "Helpful message")
+//
+// This has the benefit of using fewer lines, a common error path that has test
+// coverage, and enabling code which switches to this library to have 100%
+// coverage.
+func Must(err error, prefix string, args ...interface{}) {
+	if err != nil {
+		suffix := fmt.Sprintf("(error: %v)", err)
+		if len(args) != 0 {
+			prefix = fmt.Sprintf(prefix, args...)
+		}
+		logFatal(prefix, suffix)
+	}
+}

--- a/runtimeext/must_test.go
+++ b/runtimeext/must_test.go
@@ -1,0 +1,95 @@
+package runtimeext
+
+// The tests for this must be whitebox, because we have to override log.Fatal.
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"testing"
+)
+
+func success() error {
+	return nil
+}
+
+func fail() error {
+	return errors.New("A failure for testing")
+}
+
+func TestMustSuccess(t *testing.T) {
+	Must(success(), "Works")
+}
+
+func callPrintln(args ...interface{}) {
+	fmt.Println(args...)
+}
+
+func TestMustFailure(t *testing.T) {
+	logFatal = callPrintln
+	defer func() { logFatal = log.Fatal }()
+
+	// Technique from https://stackoverflow.com/questions/10473800/in-go-how-do-i-capture-stdout-of-a-function-into-a-string
+	// Intercept stdout
+	old := os.Stdout // keep backup of the real stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	outC := make(chan string)
+
+	// Copy the output in a separate goroutine so printing can't block indefinitely
+	go func() {
+		var buf bytes.Buffer
+		io.Copy(&buf, r)
+		outC <- buf.String()
+	}()
+
+	// Call the function which causes the output
+	Must(fail(), "Should fail")
+
+	// Return back to normal state
+	w.Close()
+	os.Stdout = old
+
+	// Find out what got read
+	out := <-outC
+
+	if string(out) != "Should fail (error: A failure for testing)\n" {
+		t.Errorf("%q != \"Should fail (error: An error for testing)\"", out)
+	}
+}
+
+func TestMustFailureWithFormatting(t *testing.T) {
+	logFatal = callPrintln
+	defer func() { logFatal = log.Fatal }()
+
+	// Technique from https://stackoverflow.com/questions/10473800/in-go-how-do-i-capture-stdout-of-a-function-into-a-string
+	// Intercept stdout
+	old := os.Stdout // keep backup of the real stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	outC := make(chan string)
+
+	// Copy the output in a separate goroutine so printing can't block indefinitely
+	go func() {
+		var buf bytes.Buffer
+		io.Copy(&buf, r)
+		outC <- buf.String()
+	}()
+
+	// Call the function which causes the output
+	Must(fail(), "Should fail with arg %d", 5)
+
+	// Return back to normal state
+	w.Close()
+	os.Stdout = old
+
+	// Find out what got read
+	out := <-outC
+
+	if string(out) != "Should fail with arg 5 (error: A failure for testing)\n" {
+		t.Errorf("%q != \"Should fail with arg 5 (error: An error for testing)\"", out)
+	}
+}


### PR DESCRIPTION
Adds code from pusher that is of general utility into M-Lab's general-purpose go library.
Cleans up .travis.yml
Adds git-hooks so that `go vet` can be run every time.