### PR TITLE
Adds httpx which eliminates a race condition.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ cache:
 
 script:
 # Run every regular unit test.
-- go test -covermode=count -coverprofile=_coverage.cov ./...
+- go test -covermode=count -coverprofile=_coverage.cov -v ./...
 # bqext should also have its integration tests run.
 - go test -covermode=count -coverprofile=_bqext.cov -v ./bqext -tags=$TEST_TAGS
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,18 +41,11 @@ cache:
   - "$HOME/google-cloud-sdk/"
 
 script:
-# This script replaces / with ___ in the coverage file names. If you have
-# two modules, one named x/y and one named x___y, then this will break. But
-# don't put triple underscores in a module name: That's bad practice anyway.
-- for module in $(find * -type d |
-                  grep -v '^git-hooks$' |
-                  grep -v '^travis$'); do
-    go test -v -covermode=count -coverprofile=${module#/#___}.cov ./$module ;
-  done
+# Run every regular unit test.
+- go test -covermode=count -coverprofile=_coverage.cov ./...
 # bqext should also have its integration tests run.
 - go test -covermode=count -coverprofile=_bqext.cov -v ./bqext -tags=$TEST_TAGS
 
 # Coveralls
-# This will fail if you name a module ___merge, so don't do that.
-- $HOME/gopath/bin/gocovmerge *.cov > ___merge.cov
-- $HOME/gopath/bin/goveralls -coverprofile=___merge.cov -service=travis-ci
+- $HOME/gopath/bin/gocovmerge *.cov > __merged.cov
+- $HOME/gopath/bin/goveralls -coverprofile=__merged.cov -service=travis-ci

--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ Utilities for testing google cloud service abstractions.
 ### flagx
 Extensions for the flag package.
 
+### httpx
+Extensions of the http package.
+
 ### osx
 Extensions of the os package.
 

--- a/httpx/README.md
+++ b/httpx/README.md
@@ -1,0 +1,10 @@
+ListenAndServe in the Go http package is impossible to use safely in an
+asynchronous way.  What we frequently want is to start the http server and have
+it run, asynchronously, in perpetuity, but not have the call return until the
+server is able to receive requests.
+
+httpx provides `ListenAndServeAsync`, which starts an http server in a
+background goroutine, but does not return until the listening socket is
+established. Therefore, once this function returns, the server can have an HTTP
+GET run against it and the GET should succeed (or at least call the appropriate
+server code).

--- a/httpx/httpx.go
+++ b/httpx/httpx.go
@@ -1,0 +1,89 @@
+// Package httpx provides generic functions which extend the capabilities of
+// the http package.
+//
+// The code here eliminates an annoying race condition in net/http that prevents
+// you from knowing when it is safe to connect to the server socket. For the
+// functions in this package, the listening socket is fully estabished when the
+// function returns, and it is safe to run an HTTP GET immediately.
+package httpx
+
+import (
+	"log"
+	"net"
+	"net/http"
+	"time"
+)
+
+var logFatalf = log.Fatalf
+
+// The code here is adapted from https://golang.org/src/net/http/server.go?s=85391:85432#L2742
+
+// tcpKeepAliveListener sets TCP keep-alive timeouts on accepted
+// connections. It's used by ListenAndServe and ListenAndServeTLS so
+// dead TCP connections (e.g. closing laptop mid-download) eventually
+// go away.
+type tcpKeepAliveListener struct {
+	*net.TCPListener
+}
+
+func (ln tcpKeepAliveListener) Accept() (net.Conn, error) {
+	tc, err := ln.AcceptTCP()
+	if err != nil {
+		return nil, err
+	}
+	tc.SetKeepAlive(true)
+	tc.SetKeepAlivePeriod(3 * time.Minute)
+	return tc, nil
+}
+
+func serve(server *http.Server, listener net.Listener) {
+	err := server.Serve(listener)
+	if err != http.ErrServerClosed {
+		logFatalf("Error, server %v closed with unexpected error %v", server, err)
+	}
+}
+
+// ListenAndServeAsync starts an http server. The server will run until
+// Shutdown() or Close() is called, but this function will return once the
+// listening socket is established.  This means that when this function
+// returns, the server is immediately available for an http GET to be run
+// against it.
+//
+// Returns a non-nil error if the listening socket can't be established. Logs a
+// fatal error if the server dies for a reason besides ErrServerClosed.
+func ListenAndServeAsync(server *http.Server) error {
+	// Start listening synchronously.
+	listener, err := net.Listen("tcp", server.Addr)
+	if err != nil {
+		return err
+	}
+	// Serve asynchronously.
+	go serve(server, tcpKeepAliveListener{listener.(*net.TCPListener)})
+	return nil
+}
+
+func serveTLS(server *http.Server, listener net.Listener, certFile, keyFile string) {
+	err := server.ServeTLS(listener, certFile, keyFile)
+	if err != http.ErrServerClosed {
+		logFatalf("Error, server %v closed with unexpected error %v", server, err)
+	}
+}
+
+// ListenAndServeTLSAsync starts an https server. The server will run until
+// Shutdown() or Close() is called, but this function will return once the
+// listening socket is established.  This means that when this function
+// returns, the server is immediately available for an https GET to be run
+// against it.
+//
+// Returns a non-nil error if the listening socket can't be established. Logs a
+// fatal error if the server dies for a reason besides ErrServerClosed.
+func ListenAndServeTLSAsync(server *http.Server, certFile, keyFile string) error {
+	// Start listening synchronously.
+	listener, err := net.Listen("tcp", server.Addr)
+	if err != nil {
+		return err
+	}
+	// Serve asynchronously.
+	go serveTLS(server, tcpKeepAliveListener{listener.(*net.TCPListener)}, certFile, keyFile)
+	return nil
+}

--- a/httpx/httpx_test.go
+++ b/httpx/httpx_test.go
@@ -1,0 +1,219 @@
+package httpx
+
+// Tests happen in the httpx package because we use whitebox testing to exercise error
+// conditions.
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"io"
+	"io/ioutil"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/kabukky/httpscerts"
+	"github.com/m-lab/go/rtx"
+)
+
+func okay(w http.ResponseWriter, req *http.Request) {
+	w.Header().Set("Content-Type", "text/plain")
+	w.Write([]byte("\nOK!"))
+}
+
+func TestListenAndServeAsync(t *testing.T) {
+	for i := 0; i < 1000; i++ {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/", okay)
+		server := &http.Server{
+			Addr:    ":9090",
+			Handler: mux,
+		}
+		rtx.Must(ListenAndServeAsync(server), "Could not start server")
+		response, err := http.Get("http://localhost:9090/")
+		if err != nil {
+			t.Fatalf("HTTP server returned %v", err)
+		}
+		content := make([]byte, 20)
+		n, err := response.Body.Read(content)
+		if err != io.EOF {
+			t.Errorf("Could not read response: %v", err)
+		}
+		if n != 4 {
+			t.Errorf("Too many bytes: %d", n)
+		}
+		server.Shutdown(context.Background())
+	}
+}
+
+func TestListenAndServeAsyncFailsWhenListenFails(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", okay)
+	server := &http.Server{
+		Addr:    ":9090",
+		Handler: mux,
+	}
+	rtx.Must(ListenAndServeAsync(server), "Could not start server")
+	defer server.Shutdown(context.Background())
+	// One server works.  The next one should fail.
+	server2 := &http.Server{
+		Addr:    ":9090",
+		Handler: mux,
+	}
+	err := ListenAndServeAsync(server2)
+	if err == nil {
+		t.Error("This should have failed")
+	}
+}
+
+type listenerWithErrors struct {
+	*net.TCPListener
+}
+
+func (l *listenerWithErrors) Accept() (net.Conn, error) {
+	return nil, errors.New("This will not ever work")
+}
+
+var fakeFatalfCount = 0
+
+func fakeFatalf(s string, args ...interface{}) {
+	log.Printf("log.Fatal called in debug mode: "+s, args...)
+	fakeFatalfCount++
+}
+
+// Whitebox test.
+func TestListenAndServeAsyncWithPermanentNetworkFailure(t *testing.T) {
+	// Make sure that we call log.Fatal when the server exits with anything other
+	// than ErrServerClosed.
+	fakeFatalfCount = 0
+	logFatalf = fakeFatalf
+	defer func() {
+		logFatalf = log.Fatalf
+		fakeFatalfCount = 0
+	}()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", okay)
+	server := &http.Server{
+		Addr:    ":9090",
+		Handler: mux,
+	}
+	if fakeFatalfCount != 0 {
+		t.Errorf("fakeFatalCount should be 0 not %d", fakeFatalfCount)
+	}
+	serve(server, &listenerWithErrors{})
+	if fakeFatalfCount != 1 {
+		t.Errorf("fakeFatalCount should be 1 not %d", fakeFatalfCount)
+	}
+	server.Shutdown(context.Background())
+}
+
+func makeTestCertsWithCleanup(sname string) (certFile, keyfile string, roots *x509.CertPool, cleanup func()) {
+	dir, err := ioutil.TempDir("", "tlsfilesfortesting")
+	rtx.Must(err, "Could not create TLS file dir")
+	key := dir + "/key.pem"
+	cert := dir + "/cert.pem"
+	rtx.Must(httpscerts.Generate(cert, key, sname), "Could not generate certs")
+	certBytes, err := ioutil.ReadFile(cert)
+	rtx.Must(err, "Could not read new cert")
+	rootCAs, err := x509.SystemCertPool()
+	rtx.Must(err, "Could not get existing CA pool")
+	if !rootCAs.AppendCertsFromPEM(certBytes) {
+		log.Fatal("Could not add new cert to root of trust")
+	}
+	return cert, key, rootCAs, func() {
+		os.RemoveAll(dir)
+	}
+}
+
+func TestListenAndServeTLSAsync(t *testing.T) {
+	cert, key, roots, cleanup := makeTestCertsWithCleanup("localhost")
+	defer cleanup()
+	client := &http.Client{Transport: &http.Transport{
+		TLSClientConfig: &tls.Config{RootCAs: roots},
+	}}
+	// 100 instead of 1000 because TLS server setup and teardown is 10x slower than non-TLS.
+	for i := 0; i < 100; i++ {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/", okay)
+		server := &http.Server{
+			Addr:    ":9090",
+			Handler: mux,
+		}
+		rtx.Must(ListenAndServeTLSAsync(server, cert, key), "Could not start server")
+		response, err := client.Get("https://localhost:9090/")
+		if err != nil {
+			t.Fatalf("HTTP server returned %v", err)
+		}
+		content := make([]byte, 20)
+		n, err := response.Body.Read(content)
+		if err != io.EOF {
+			t.Errorf("Could not read response: %v", err)
+		}
+		if n != 4 {
+			t.Errorf("Too many bytes: %d", n)
+		}
+		server.Shutdown(context.Background())
+	}
+}
+
+func TestListenAndServeTLSAsyncFailsWhenListenFails(t *testing.T) {
+	cert, key, roots, cleanup := makeTestCertsWithCleanup("localhost")
+	defer cleanup()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", okay)
+	server := &http.Server{
+		Addr:    ":9092",
+		Handler: mux,
+	}
+	rtx.Must(ListenAndServeTLSAsync(server, cert, key), "Could not start server")
+	defer server.Shutdown(context.Background())
+	// One race condition remains: if the server is not fully set up by the time
+	// Shutdown is called, then the early shutdown might cause ServeTLS to return a
+	// non-ErrServerClosed error. By running a GET here, we make sure that the
+	// server is up and running, which ensures that its setup has completed.
+	client := &http.Client{Transport: &http.Transport{
+		TLSClientConfig: &tls.Config{RootCAs: roots},
+	}}
+	_, err := client.Get("https://localhost:9092/")
+	rtx.Must(err, "Could not connect to local TLS server")
+	// One server works.  The next one should fail.
+	server2 := &http.Server{
+		Addr:    ":9092",
+		Handler: mux,
+	}
+	err = ListenAndServeTLSAsync(server2, cert, key)
+	if err == nil {
+		t.Error("This should have failed")
+	}
+}
+
+// Whitebox test.
+func TestListenAndServeTLSAsyncWithPermanentNetworkFailure(t *testing.T) {
+	cert, key, _, _ := makeTestCertsWithCleanup("localhost")
+	//defer cleanup()
+	// Make sure that we call log.Fatal when the server exits with anything other
+	// than ErrServerClosed.
+	fakeFatalfCount = 0
+	logFatalf = fakeFatalf
+	defer func() {
+		logFatalf = log.Fatalf
+		fakeFatalfCount = 0
+	}()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", okay)
+	server := &http.Server{
+		Addr:    ":9091",
+		Handler: mux,
+	}
+	if fakeFatalfCount != 0 {
+		t.Errorf("fakeFatalCount should be 0 not %d", fakeFatalfCount)
+	}
+	serveTLS(server, &listenerWithErrors{}, cert, key)
+	if fakeFatalfCount != 1 {
+		t.Errorf("fakeFatalCount should be 1 not %d", fakeFatalfCount)
+	}
+}

--- a/httpx/httpx_test.go
+++ b/httpx/httpx_test.go
@@ -54,14 +54,14 @@ func TestListenAndServeAsyncFailsWhenListenFails(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", okay)
 	server := &http.Server{
-		Addr:    ":9090",
+		Addr:    ":9091",
 		Handler: mux,
 	}
 	rtx.Must(ListenAndServeAsync(server), "Could not start server")
 	defer server.Shutdown(context.Background())
 	// One server works.  The next one should fail.
 	server2 := &http.Server{
-		Addr:    ":9090",
+		Addr:    ":9091",
 		Handler: mux,
 	}
 	err := ListenAndServeAsync(server2)
@@ -98,7 +98,7 @@ func TestListenAndServeAsyncWithPermanentNetworkFailure(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", okay)
 	server := &http.Server{
-		Addr:    ":9090",
+		Addr:    ":9092",
 		Handler: mux,
 	}
 	if fakeFatalfCount != 0 {
@@ -140,11 +140,11 @@ func TestListenAndServeTLSAsync(t *testing.T) {
 		mux := http.NewServeMux()
 		mux.HandleFunc("/", okay)
 		server := &http.Server{
-			Addr:    ":9090",
+			Addr:    ":9093",
 			Handler: mux,
 		}
 		rtx.Must(ListenAndServeTLSAsync(server, cert, key), "Could not start server")
-		response, err := client.Get("https://localhost:9090/")
+		response, err := client.Get("https://localhost:9093/")
 		if err != nil {
 			t.Fatalf("HTTP server returned %v", err)
 		}
@@ -166,7 +166,7 @@ func TestListenAndServeTLSAsyncFailsWhenListenFails(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", okay)
 	server := &http.Server{
-		Addr:    ":9092",
+		Addr:    ":9094",
 		Handler: mux,
 	}
 	rtx.Must(ListenAndServeTLSAsync(server, cert, key), "Could not start server")
@@ -178,11 +178,11 @@ func TestListenAndServeTLSAsyncFailsWhenListenFails(t *testing.T) {
 	client := &http.Client{Transport: &http.Transport{
 		TLSClientConfig: &tls.Config{RootCAs: roots},
 	}}
-	_, err := client.Get("https://localhost:9092/")
+	_, err := client.Get("https://localhost:9094/")
 	rtx.Must(err, "Could not connect to local TLS server")
 	// One server works.  The next one should fail.
 	server2 := &http.Server{
-		Addr:    ":9092",
+		Addr:    ":9094",
 		Handler: mux,
 	}
 	err = ListenAndServeTLSAsync(server2, cert, key)
@@ -206,7 +206,7 @@ func TestListenAndServeTLSAsyncWithPermanentNetworkFailure(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", okay)
 	server := &http.Server{
-		Addr:    ":9091",
+		Addr:    ":9095",
 		Handler: mux,
 	}
 	if fakeFatalfCount != 0 {

--- a/httpx/httpx_test.go
+++ b/httpx/httpx_test.go
@@ -193,8 +193,8 @@ func TestListenAndServeTLSAsyncFailsWhenListenFails(t *testing.T) {
 
 // Whitebox test.
 func TestListenAndServeTLSAsyncWithPermanentNetworkFailure(t *testing.T) {
-	cert, key, _, _ := makeTestCertsWithCleanup("localhost")
-	//defer cleanup()
+	cert, key, _, cleanup := makeTestCertsWithCleanup("localhost")
+	defer cleanup()
 	// Make sure that we call log.Fatal when the server exits with anything other
 	// than ErrServerClosed.
 	fakeFatalfCount = 0


### PR DESCRIPTION
Creates two new functions which eliminate the "is it ready yet?" race condition that normally results from 
`go srv.ListenAndServe()`. These race conditions have already cost multiple people hours of debugging, so this yak shave is definitely worth it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/go/23)
<!-- Reviewable:end -->
