### PR TITLE
httpx.ListenAndServeAsync now updates the .Addr of the passed-in server.

### DIFF
--- a/httpx/httpx.go
+++ b/httpx/httpx.go
@@ -53,7 +53,7 @@ func serve(server *http.Server, listener net.Listener) {
 // Returns a non-nil error if the listening socket can't be established. Logs a
 // fatal error if the server dies for a reason besides ErrServerClosed. If the
 // server.Addr is set to :0, then after this function returns server.Addr will
-// contain the address and port which this server is listenting on.
+// contain the address and port which this server is listening on.
 func ListenAndServeAsync(server *http.Server) error {
 	// Start listening synchronously.
 	listener, err := net.Listen("tcp", server.Addr)

--- a/httpx/httpx_test.go
+++ b/httpx/httpx_test.go
@@ -30,11 +30,11 @@ func TestListenAndServeAsync(t *testing.T) {
 		mux := http.NewServeMux()
 		mux.HandleFunc("/", okay)
 		server := &http.Server{
-			Addr:    ":9090",
+			Addr:    ":0",
 			Handler: mux,
 		}
 		rtx.Must(ListenAndServeAsync(server), "Could not start server")
-		response, err := http.Get("http://localhost:9090/")
+		response, err := http.Get("http://" + server.Addr + "/")
 		if err != nil {
 			t.Fatalf("HTTP server returned %v", err)
 		}


### PR DESCRIPTION
For reasons that are complicated enough to cause a paragraph-long comment, this functionality is not added to ListenAndServeTLSAsync

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/go/25)
<!-- Reviewable:end -->
