### PR TITLE
Add flagx.FileBytes type

### DIFF
--- a/flagx/filebytes.go
+++ b/flagx/filebytes.go
@@ -1,0 +1,30 @@
+package flagx
+
+import (
+	"encoding/hex"
+	"io/ioutil"
+)
+
+// FileBytes holds the file bytes.
+type FileBytes []byte
+
+// Get retrieves the value contained in the flag.
+func (fb FileBytes) Get() interface{} {
+	return fb
+}
+
+// Set accepts a filename and reads the bytes associated with that file.
+func (fb *FileBytes) Set(s string) error {
+	b, err := ioutil.ReadFile(s)
+	if err != nil {
+		return err
+	}
+	*fb = b
+	return nil
+}
+
+// String reports the FileBytes as a raw string. Unprintable characters will
+// still be unprintable.
+func (fb FileBytes) String() string {
+	return hex.Dump(fb)
+}

--- a/flagx/filebytes_test.go
+++ b/flagx/filebytes_test.go
@@ -1,0 +1,58 @@
+package flagx_test
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/m-lab/go/rtx"
+
+	"github.com/m-lab/go/flagx"
+)
+
+func TestFileBytes(t *testing.T) {
+	tests := []struct {
+		name        string
+		content     string
+		hexdump     string
+		badFilename string
+		wantErr     bool
+	}{
+		{
+			name:    "okay",
+			content: "1234567890abcdef",
+			hexdump: "00000000  31 32 33 34 35 36 37 38  39 30 61 62 63 64 65 66  |1234567890abcdef|\n",
+		},
+		{
+			name:        "error-bad-filename",
+			badFilename: "this-file-does-not-exist",
+			wantErr:     true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var fname string
+			var f *os.File
+			var err error
+
+			if tt.badFilename == "" {
+				f, err = ioutil.TempFile("", "-filebytes")
+				rtx.Must(err, "Failed to create tempfile")
+				defer os.Remove(f.Name())
+				f.WriteString(tt.content)
+				fname = f.Name()
+			}
+
+			fb := &flagx.FileBytes{}
+			if err := fb.Set(fname); (err != nil) != tt.wantErr {
+				t.Errorf("FileBytes.Set() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr && tt.content != (string)(fb.Get().(flagx.FileBytes)) {
+				t.Errorf("FileBytes.Get() want = %q, got %q", tt.content, string(*fb))
+			}
+			if !tt.wantErr && tt.hexdump != fb.String() {
+				t.Errorf("FileBytes.String() want = %q, got %q", tt.hexdump, fb.String())
+			}
+		})
+	}
+}

--- a/flagx/filebytes_test.go
+++ b/flagx/filebytes_test.go
@@ -12,11 +12,10 @@ import (
 
 func TestFileBytes(t *testing.T) {
 	tests := []struct {
-		name        string
-		content     string
-		hexdump     string
-		badFilename string
-		wantErr     bool
+		name    string
+		content string
+		hexdump string
+		wantErr bool
 	}{
 		{
 			name:    "okay",
@@ -24,9 +23,8 @@ func TestFileBytes(t *testing.T) {
 			hexdump: "00000000  31 32 33 34 35 36 37 38  39 30 61 62 63 64 65 66  |1234567890abcdef|\n",
 		},
 		{
-			name:        "error-bad-filename",
-			badFilename: "this-file-does-not-exist",
-			wantErr:     true,
+			name:    "error-bad-filename",
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {
@@ -35,12 +33,14 @@ func TestFileBytes(t *testing.T) {
 			var f *os.File
 			var err error
 
-			if tt.badFilename == "" {
+			if !tt.wantErr {
 				f, err = ioutil.TempFile("", "-filebytes")
 				rtx.Must(err, "Failed to create tempfile")
 				defer os.Remove(f.Name())
 				f.WriteString(tt.content)
 				fname = f.Name()
+			} else {
+				fname = "this-is-not-a-file"
 			}
 
 			fb := &flagx.FileBytes{}


### PR DESCRIPTION
This change adds a new flagx type called FileBytes that automatically reads the content of the given file as a `[]byte`, handling any error during flag parsing and simplifying application logic.

