### PR TITLE
Improved debug output for filebytes.

### DIFF
--- a/flagx/filebytes.go
+++ b/flagx/filebytes.go
@@ -1,7 +1,6 @@
 package flagx
 
 import (
-	"encoding/hex"
 	"io/ioutil"
 )
 
@@ -9,12 +8,13 @@ import (
 // given filename as a `[]byte`, handling errors during flag parsing.
 type FileBytes []byte
 
-// Get retrieves the value contained in the flag.
+// Get retrieves the bytes read from the file (or the default bytes).
 func (fb FileBytes) Get() interface{} {
 	return fb
 }
 
-// Set accepts a filename and reads the bytes associated with that file.
+// Set accepts a filename and reads the bytes associated with that file into the
+// FileBytes storage.
 func (fb *FileBytes) Set(s string) error {
 	b, err := ioutil.ReadFile(s)
 	if err != nil {
@@ -24,7 +24,12 @@ func (fb *FileBytes) Set(s string) error {
 	return nil
 }
 
-// String reports the FileBytes content as a hexdump.
+// String reports the FileBytes content as a string.
+//
+// FileBytes are awkward to represent in help text, and such help text is the
+// main use of the Stringer interface for this flag. Help text like:
+//   "Sets the file containing the prefix string. The default file contents are: " + fb.String()
+// is recommended.
 func (fb FileBytes) String() string {
-	return hex.Dump(fb)
+	return string([]byte(fb))
 }

--- a/flagx/filebytes_test.go
+++ b/flagx/filebytes_test.go
@@ -15,13 +15,11 @@ func TestFileBytes(t *testing.T) {
 	tests := []struct {
 		name    string
 		content string
-		hexdump string
 		wantErr bool
 	}{
 		{
 			name:    "okay",
 			content: "1234567890abcdef",
-			hexdump: "00000000  31 32 33 34 35 36 37 38  39 30 61 62 63 64 65 66  |1234567890abcdef|\n",
 		},
 		{
 			name:    "error-bad-filename",
@@ -40,6 +38,7 @@ func TestFileBytes(t *testing.T) {
 				defer os.Remove(f.Name())
 				f.WriteString(tt.content)
 				fname = f.Name()
+				f.Close()
 			} else {
 				fname = "this-is-not-a-file"
 			}
@@ -51,8 +50,8 @@ func TestFileBytes(t *testing.T) {
 			if !tt.wantErr && tt.content != (string)(fb.Get().(flagx.FileBytes)) {
 				t.Errorf("FileBytes.Get() want = %q, got %q", tt.content, string(*fb))
 			}
-			if !tt.wantErr && tt.hexdump != fb.String() {
-				t.Errorf("FileBytes.String() want = %q, got %q", tt.hexdump, fb.String())
+			if !tt.wantErr && string(tt.content) != fb.String() {
+				t.Errorf("FileBytes.String() want = %q, got %q", tt.content, fb.String())
 			}
 		})
 	}
@@ -60,7 +59,6 @@ func TestFileBytes(t *testing.T) {
 
 // Successful compilation of this function means that FileBytes implements the
 // flag.Getter interface. The function need not be called.
-func assertFlagGetter(in flag.Getter) {
-	var b flagx.FileBytes
+func assertFlagGetter(b flagx.FileBytes) {
 	func(in flag.Getter) {}(&b)
 }

--- a/flagx/filebytes_test.go
+++ b/flagx/filebytes_test.go
@@ -50,7 +50,7 @@ func TestFileBytes(t *testing.T) {
 			if !tt.wantErr && tt.content != (string)(fb.Get().(flagx.FileBytes)) {
 				t.Errorf("FileBytes.Get() want = %q, got %q", tt.content, string(*fb))
 			}
-			if !tt.wantErr && string(tt.content) != fb.String() {
+			if !tt.wantErr && tt.content != fb.String() {
 				t.Errorf("FileBytes.String() want = %q, got %q", tt.content, fb.String())
 			}
 		})


### PR DESCRIPTION
Got some weird output when testing out UUID code.  The hexdump is pretty inconvenient, so this moves it to being a string conversion.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/go/39)
<!-- Reviewable:end -->
