### PR TITLE
Add flagx.StringArray type

### DIFF
--- a/flagx/stringarray.go
+++ b/flagx/stringarray.go
@@ -3,7 +3,9 @@ package flagx
 import "fmt"
 
 // StringArray is a new flag type. It appends the flag parameter to an
-// `[]string` allowing the parameter to be specified multiple times.
+// `[]string` allowing the parameter to be specified multiple times. Unlike
+// other Flag types, the default argument should almost always be the empty
+// array, because there is no way to remove an element, only to add one.
 type StringArray []string
 
 // Get retrieves the value contained in the flag.

--- a/flagx/stringarray.go
+++ b/flagx/stringarray.go
@@ -1,0 +1,23 @@
+package flagx
+
+import "fmt"
+
+// StringArray is a new flag type. It appends the flag parameter to an
+// `[]string` allowing the parameter to be specified multiple times.
+type StringArray []string
+
+// Get retrieves the value contained in the flag.
+func (sa StringArray) Get() interface{} {
+	return sa
+}
+
+// Set accepts a string parameter and appends it to the associated StringArray.
+func (sa *StringArray) Set(s string) error {
+	*sa = append(*sa, s)
+	return nil
+}
+
+// String reports the StringArray as a Go value.
+func (sa StringArray) String() string {
+	return fmt.Sprintf("%#v", []string(sa))
+}

--- a/flagx/stringarray_test.go
+++ b/flagx/stringarray_test.go
@@ -1,0 +1,54 @@
+package flagx_test
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/m-lab/go/flagx"
+)
+
+func TestStringArray(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		repr string
+	}{
+		{
+			name: "okay",
+			args: []string{"a", "b"},
+			repr: `[]string{"a", "b"}`,
+		},
+		{
+			name: "empty",
+			args: []string{},
+			repr: `[]string{}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sa := &flagx.StringArray{}
+			for i := range tt.args {
+				if err := sa.Set(tt.args[i]); err != nil {
+					t.Errorf("StringArray.Set() error = %v, want nil", err)
+				}
+			}
+			v := (sa.Get().(flagx.StringArray))
+			for i := range v {
+				if v[i] != tt.args[i] {
+					t.Errorf("StringArray.Get() want[%d] = %q, got[%d] %q",
+						i, tt.args[i], i, v[i])
+				}
+			}
+			if tt.repr != sa.String() {
+				t.Errorf("StringArray.String() want = %q, got %q", tt.repr, sa.String())
+			}
+		})
+	}
+}
+
+// Successful compilation of this function means that StringArray implements the
+// flag.Getter interface. The function need not be called.
+func assertFlagGetterStringArray(in flag.Getter) {
+	var b flagx.StringArray
+	func(in flag.Getter) {}(&b)
+}

--- a/flagx/stringarray_test.go
+++ b/flagx/stringarray_test.go
@@ -48,7 +48,6 @@ func TestStringArray(t *testing.T) {
 
 // Successful compilation of this function means that StringArray implements the
 // flag.Getter interface. The function need not be called.
-func assertFlagGetterStringArray(in flag.Getter) {
-	var b flagx.StringArray
+func assertFlagGetterStringArray(b flagx.StringArray) {
 	func(in flag.Getter) {}(&b)
 }


### PR DESCRIPTION
`flagx.ArgsFromEnv` does not work on types from the `github.com/spf13/pflag` package. This change adds an array type to allow repeated flags while preserving compatibility with `flagx.ArgsFromEnv` for all other flags.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/go/41)
<!-- Reviewable:end -->
