### PR TITLE
Move LintMetrics to promtest package

### DIFF
--- a/prometheusx/prom.go
+++ b/prometheusx/prom.go
@@ -1,24 +1,16 @@
-// Package prometheusx provides a canonical way to expose Prometheus metrics
-// and provides a utility function for linting those metrics.
+// Package prometheusx provides a canonical way to expose Prometheus metrics.
 package prometheusx
 
 import (
-	"bytes"
-	"context"
-	"fmt"
-	"io/ioutil"
-	"log"
 	"net/http"
 	"net/http/pprof"
 	"strconv"
-	"testing"
 
 	"github.com/m-lab/go/httpx"
 	"github.com/m-lab/go/rtx"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"github.com/prometheus/prometheus/util/promlint"
 )
 
 var (
@@ -79,34 +71,4 @@ func MustStartPrometheus(addr string) *http.Server {
 
 	// Return the server
 	return server
-}
-
-// LintMetrics will ensure that the names of the passed-in Promethus metrics
-// follow all best practices. If the passed-in testing.T is nil, then all lint
-// errors are just log messages. If a real testing.T is passed in, then lint
-// errors cause test failures.
-func LintMetrics(t *testing.T) (passed bool) {
-	srv := MustStartPrometheus(":0")
-	defer srv.Shutdown(context.Background())
-
-	metricReader, err := http.Get("http://" + srv.Addr + "/metrics")
-	rtx.Must(err, "Could not GET metrics")
-	metricBytes, err := ioutil.ReadAll(metricReader.Body)
-	rtx.Must(err, "Could not read metrics")
-
-	metricsLinter := promlint.New(bytes.NewBuffer(metricBytes))
-	problems, err := metricsLinter.Lint()
-	rtx.Must(err, "Could not lint metrics")
-
-	passed = true
-	for _, p := range problems {
-		passed = false
-		msg := fmt.Sprintf("Bad metric %v: %v", p.Metric, p.Text)
-		if t == nil {
-			log.Println(msg)
-		} else {
-			t.Error(msg)
-		}
-	}
-	return passed
 }

--- a/prometheusx/prom_test.go
+++ b/prometheusx/prom_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/m-lab/go/prometheusx"
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 func TestMustStartPrometheus(t *testing.T) {
@@ -21,44 +20,5 @@ func TestMustStartPrometheusOnEmptyAddr(t *testing.T) {
 	defer srv.Shutdown(context.Background())
 	if srv.Addr == ":0" {
 		t.Error("We should never get back an empty address")
-	}
-}
-
-func TestLintMetricsEmpty(t *testing.T) {
-	// No metrics.
-	prometheusx.LintMetrics(t)
-	if !prometheusx.LintMetrics(nil) {
-		t.Error("Failed to lint empty metrics")
-	}
-}
-
-func TestLintMetricsGoodMetric(t *testing.T) {
-	// One good metric.
-	goodC := prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "good_total",
-		Help: "Counts good things",
-	})
-	prometheus.MustRegister(goodC)
-	defer prometheus.Unregister(goodC)
-	prometheusx.LintMetrics(t)
-	if !prometheusx.LintMetrics(nil) {
-		t.Error("Failed to lint one good metric")
-	}
-}
-
-func TestLintMetricsBadMetric(t *testing.T) {
-	// One bad metric.
-	badC := prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "bad_name_name_for_a_counter",
-	})
-	prometheus.MustRegister(badC)
-	defer prometheus.Unregister(badC)
-	subT := &testing.T{}
-	prometheusx.LintMetrics(subT)
-	if !subT.Failed() {
-		t.Errorf("On bad metrics the test should fail")
-	}
-	if prometheusx.LintMetrics(nil) {
-		t.Error("Failed to lint error on one bad metric")
 	}
 }

--- a/prometheusx/promtest/promtest.go
+++ b/prometheusx/promtest/promtest.go
@@ -1,0 +1,46 @@
+// Package promtest provides a utility function for linting Prometheus metrics.
+package promtest
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"testing"
+
+	"github.com/m-lab/go/prometheusx"
+	"github.com/m-lab/go/rtx"
+	"github.com/prometheus/prometheus/util/promlint"
+)
+
+// LintMetrics will ensure that the names of the passed-in Promethus metrics
+// follow all best practices. If the passed-in testing.T is nil, then all lint
+// errors are just log messages. If a real testing.T is passed in, then lint
+// errors cause test failures.
+func LintMetrics(t *testing.T) (passed bool) {
+	srv := prometheusx.MustStartPrometheus(":0")
+	defer srv.Shutdown(context.Background())
+
+	metricReader, err := http.Get("http://" + srv.Addr + "/metrics")
+	rtx.Must(err, "Could not GET metrics")
+	metricBytes, err := ioutil.ReadAll(metricReader.Body)
+	rtx.Must(err, "Could not read metrics")
+
+	metricsLinter := promlint.New(bytes.NewBuffer(metricBytes))
+	problems, err := metricsLinter.Lint()
+	rtx.Must(err, "Could not lint metrics")
+
+	passed = true
+	for _, p := range problems {
+		passed = false
+		msg := fmt.Sprintf("Bad metric %v: %v", p.Metric, p.Text)
+		if t == nil {
+			log.Println(msg)
+		} else {
+			t.Error(msg)
+		}
+	}
+	return passed
+}

--- a/prometheusx/promtest/promtest_test.go
+++ b/prometheusx/promtest/promtest_test.go
@@ -1,0 +1,47 @@
+package promtest_test
+
+import (
+	"testing"
+
+	"github.com/m-lab/go/prometheusx/promtest"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func TestLintMetricsEmpty(t *testing.T) {
+	// No metrics.
+	promtest.LintMetrics(t)
+	if !promtest.LintMetrics(nil) {
+		t.Error("Failed to lint empty metrics")
+	}
+}
+
+func TestLintMetricsGoodMetric(t *testing.T) {
+	// One good metric.
+	goodC := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "good_total",
+		Help: "Counts good things",
+	})
+	prometheus.MustRegister(goodC)
+	defer prometheus.Unregister(goodC)
+	promtest.LintMetrics(t)
+	if !promtest.LintMetrics(nil) {
+		t.Error("Failed to lint one good metric")
+	}
+}
+
+func TestLintMetricsBadMetric(t *testing.T) {
+	// One bad metric.
+	badC := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "bad_name_name_for_a_counter",
+	})
+	prometheus.MustRegister(badC)
+	defer prometheus.Unregister(badC)
+	subT := &testing.T{}
+	promtest.LintMetrics(subT)
+	if !subT.Failed() {
+		t.Errorf("On bad metrics the test should fail")
+	}
+	if promtest.LintMetrics(nil) {
+		t.Error("Failed to lint error on one bad metric")
+	}
+}


### PR DESCRIPTION
By importing the system "testing" package, any users of the `prometheusx` package inherited a long list of "testing" flags that would almost never be needed (see below) by users of `prometheusx.MustStartPrometheus`.

This change adds a new sub package of prometheusx named `promtest` that contains the `LintMetrics` function. No new code was added.

This change is not backward compatible.

```
2019/04/01 02:34:56 argsfromenv.go:38: Argument test.bench=
2019/04/01 02:34:56 argsfromenv.go:38: Argument test.benchmem=false
2019/04/01 02:34:56 argsfromenv.go:38: Argument test.benchtime=1s
2019/04/01 02:34:56 argsfromenv.go:38: Argument test.blockprofile=
2019/04/01 02:34:56 argsfromenv.go:38: Argument test.blockprofilerate=1
2019/04/01 02:34:56 argsfromenv.go:38: Argument test.count=1
2019/04/01 02:34:56 argsfromenv.go:38: Argument test.coverprofile=
2019/04/01 02:34:56 argsfromenv.go:38: Argument test.cpu=
2019/04/01 02:34:56 argsfromenv.go:38: Argument test.cpuprofile=
2019/04/01 02:34:56 argsfromenv.go:38: Argument test.failfast=false
2019/04/01 02:34:56 argsfromenv.go:38: Argument test.list=
2019/04/01 02:34:56 argsfromenv.go:38: Argument test.memprofile=
2019/04/01 02:34:56 argsfromenv.go:38: Argument test.memprofilerate=0
2019/04/01 02:34:56 argsfromenv.go:38: Argument test.mutexprofile=
2019/04/01 02:34:56 argsfromenv.go:38: Argument test.mutexprofilefraction=1
2019/04/01 02:34:56 argsfromenv.go:38: Argument test.outputdir=
2019/04/01 02:34:56 argsfromenv.go:38: Argument test.parallel=4
2019/04/01 02:34:56 argsfromenv.go:38: Argument test.run=
2019/04/01 02:34:56 argsfromenv.go:38: Argument test.short=false
2019/04/01 02:34:56 argsfromenv.go:38: Argument test.testlogfile=/var/log/...
2019/04/01 02:34:56 argsfromenv.go:38: Argument test.timeout=0s
2019/04/01 02:34:56 argsfromenv.go:38: Argument test.trace=
2019/04/01 02:34:56 argsfromenv.go:38: Argument test.v=true
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/go/43)
<!-- Reviewable:end -->
