### PR TITLE
CaptureLog and LogEvery

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@
 #  * test and build the go code
 #
 language: go
+go:
+- "1.12"
+
 dist: xenial
 
 before_install:

--- a/logx/export_test.go
+++ b/logx/export_test.go
@@ -1,0 +1,13 @@
+package logx
+
+import "os"
+
+func BadPipeForTest() {
+	pipe = func() (r *os.File, w *os.File, err error) {
+		return nil, nil, os.ErrNotExist
+	}
+}
+
+func RestorePipeForTest() {
+	pipe = os.Pipe
+}

--- a/logx/logx.go
+++ b/logx/logx.go
@@ -1,12 +1,50 @@
 // Package logx provides very useful utilities for logging.
 // I hesitate to create it, for fear we will add too much stuff to it.  But LogEvery seems worth it.
+// This packages uses the MIT license, to respect the corresponding license from kami-zh/go-capture
 package logx
 
+/*
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to
+do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or
+substantial portions of the Software.
+*/
+
 import (
+	"bytes"
+	"io"
+	"log"
+	"os"
 	"sync/atomic"
 	"time"
 	"unsafe"
 )
+
+// CaptureLog captures all output from log.Println, etc.
+// Adapted from github.com/kami-zh
+func CaptureLog(f func()) string {
+	r, w, err := os.Pipe()
+	if err != nil {
+		panic(err)
+	}
+
+	log.SetOutput(w)
+	defer func() {
+		log.SetOutput(os.Stderr)
+	}()
+
+	f()
+	w.Close()
+
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+
+	return buf.String()
+}
 
 // A Logger has basic Printf and Println functions.
 type Logger interface {
@@ -19,26 +57,31 @@ type logEvery struct {
 	interval time.Duration
 }
 
-// Should be handled with atomic update
-var lastDecodeLogTime = unsafe.Pointer(&time.Time{})
-
 // NewLogEvery creates a logger that will log not more than once every interval.
 func NewLogEvery(interval time.Duration) Logger {
 	return &logEvery{unsafe.Pointer(&time.Time{}), interval}
 }
 
-func (log *logEvery) Println(v ...interface{}) {
+func (le *logEvery) ok() bool {
+	now := time.Now()
+	oldPtr := atomic.LoadPointer(&le.lastTime)
+	last := *(*time.Time)(oldPtr)
+	if now.Sub(last) < le.interval {
+		return false
+	}
+	// If this fails, then some other thread won the race.
+	return atomic.CompareAndSwapPointer(&le.lastTime, oldPtr, unsafe.Pointer(&now))
+}
+
+func (le *logEvery) Println(v ...interface{}) {
+	if le.ok() {
+		log.Println(v...)
+	}
 }
 
 // LogEvery takes an interval and pointer to a time.Time, and determines whether to produce the log or not.
-func (log *logEvery) Printf(fmt string, v ...interface{}) {
-	now := time.Now()
-	oldPtr := atomic.LoadPointer(&log.lastTime)
-	last := *(*time.Time)(oldPtr)
-	if now.Sub(last) < log.interval {
-		return
-	}
-	if atomic.CompareAndSwapPointer(&log.lastTime, oldPtr, unsafe.Pointer(&now)) {
-		log.Println(v...)
+func (le *logEvery) Printf(fmt string, v ...interface{}) {
+	if le.ok() {
+		log.Printf(fmt, v...)
 	}
 }

--- a/logx/logx.go
+++ b/logx/logx.go
@@ -24,10 +24,14 @@ import (
 	"unsafe"
 )
 
+// This indirection allows breaking os.Pipe call for testing.
+// Trying it out.  Seems a bit ugly.
+var pipe = os.Pipe
+
 // CaptureLog captures all output from log.Println, etc.
 // Adapted from github.com/kami-zh
 func CaptureLog(logger *log.Logger, f func()) (string, error) {
-	r, w, err := os.Pipe()
+	r, w, err := pipe()
 	if err != nil {
 		return "", err
 	}

--- a/logx/logx.go
+++ b/logx/logx.go
@@ -26,10 +26,10 @@ import (
 
 // CaptureLog captures all output from log.Println, etc.
 // Adapted from github.com/kami-zh
-func CaptureLog(logger *log.Logger, f func()) string {
+func CaptureLog(logger *log.Logger, f func()) (string, error) {
 	r, w, err := os.Pipe()
 	if err != nil {
-		panic(err)
+		return "", err
 	}
 
 	if logger != nil {
@@ -55,7 +55,7 @@ func CaptureLog(logger *log.Logger, f func()) string {
 	var buf bytes.Buffer
 	io.Copy(&buf, r)
 
-	return buf.String()
+	return buf.String(), nil
 }
 
 // A Logger has basic Printf and Println functions.

--- a/logx/logx.go
+++ b/logx/logx.go
@@ -1,0 +1,44 @@
+// Package logx provides very useful utilities for logging.
+// I hesitate to create it, for fear we will add too much stuff to it.  But LogEvery seems worth it.
+package logx
+
+import (
+	"sync/atomic"
+	"time"
+	"unsafe"
+)
+
+// A Logger has basic Printf and Println functions.
+type Logger interface {
+	Println(v ...interface{})
+	Printf(fmt string, v ...interface{})
+}
+
+type logEvery struct {
+	lastTime unsafe.Pointer
+	interval time.Duration
+}
+
+// Should be handled with atomic update
+var lastDecodeLogTime = unsafe.Pointer(&time.Time{})
+
+// NewLogEvery creates a logger that will log not more than once every interval.
+func NewLogEvery(interval time.Duration) Logger {
+	return &logEvery{unsafe.Pointer(&time.Time{}), interval}
+}
+
+func (log *logEvery) Println(v ...interface{}) {
+}
+
+// LogEvery takes an interval and pointer to a time.Time, and determines whether to produce the log or not.
+func (log *logEvery) Printf(fmt string, v ...interface{}) {
+	now := time.Now()
+	oldPtr := atomic.LoadPointer(&log.lastTime)
+	last := *(*time.Time)(oldPtr)
+	if now.Sub(last) < log.interval {
+		return
+	}
+	if atomic.CompareAndSwapPointer(&log.lastTime, oldPtr, unsafe.Pointer(&now)) {
+		log.Println(v...)
+	}
+}

--- a/logx/logx_test.go
+++ b/logx/logx_test.go
@@ -1,0 +1,78 @@
+package logx_test
+
+import (
+	"log"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/m-lab/go/logx"
+)
+
+func init() {
+	// Always prepend the filename and line number.
+	log.SetFlags(log.LstdFlags | log.Lshortfile)
+}
+
+func TestCaptureLog(t *testing.T) {
+	out := logx.CaptureLog(func() {
+		logger := logx.NewLogEvery(time.Millisecond)
+		start := time.Now()
+		log.Println("key phrase")
+		for time.Since(start) < 10*time.Millisecond {
+			logger.Println(time.Now())
+		}
+	})
+
+	if !strings.Contains(out, "logx_test.go:") {
+		t.Error("Missing short filename")
+	}
+
+	if !strings.Contains(out, "key phrase") {
+		t.Error("Missing key phrase")
+	}
+}
+
+func TestLogEvery_Println(t *testing.T) {
+	out := logx.CaptureLog(func() {
+		logger := logx.NewLogEvery(time.Millisecond)
+		start := time.Now()
+		for ; time.Since(start) < 10*time.Millisecond; time.Sleep(100 * time.Microsecond) {
+			logger.Println("foobar")
+		}
+	})
+
+	if !strings.Contains(out, "logx.go:") {
+		t.Error("Missing short filename")
+	}
+	lines := strings.Split(out, "\n")
+	// Should be 10 or 11.  Error if more than 12.
+	if len(lines) > 12 {
+		t.Error("Too many logs", len(lines))
+	}
+	if len(lines) < 9 {
+		t.Error("Too few logs", len(lines))
+	}
+}
+
+func TestLogEvery_Printf(t *testing.T) {
+	out := logx.CaptureLog(func() {
+		logger := logx.NewLogEvery(time.Millisecond)
+		start := time.Now()
+		for ; time.Since(start) < 10*time.Millisecond; time.Sleep(100 * time.Microsecond) {
+			logger.Printf("%s\n", "foobar")
+		}
+	})
+
+	if !strings.Contains(out, "logx.go:") {
+		t.Error("Missing short filename")
+	}
+	lines := strings.Split(out, "\n")
+	// Should be 10 or 11.  Error if more than 12.
+	if len(lines) > 12 {
+		t.Error("Too many logs", len(lines))
+	}
+	if len(lines) < 9 {
+		t.Error("Too few logs", len(lines))
+	}
+}

--- a/logx/logx_test.go
+++ b/logx/logx_test.go
@@ -36,6 +36,22 @@ func TestCaptureLog(t *testing.T) {
 	}
 }
 
+func TestCaptureLog_BadPipe(t *testing.T) {
+	logx.BadPipeForTest()
+	defer logx.RestorePipeForTest()
+	_, err := logx.CaptureLog(nil, func() {
+		logger := logx.NewLogEvery(nil, time.Millisecond)
+		start := time.Now()
+		log.Println("key phrase")
+		for time.Since(start) < 10*time.Millisecond {
+			logger.Println(time.Now())
+		}
+	})
+	if err == nil {
+		t.Fatal("Should have gracefully handled error")
+	}
+}
+
 func TestLogEvery_Println(t *testing.T) {
 	logger := log.New(os.Stderr, "", log.LstdFlags|log.Lshortfile)
 	out, err := logx.CaptureLog(logger, func() {

--- a/logx/logx_test.go
+++ b/logx/logx_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/m-lab/go/logx"
+	"github.com/m-lab/go/rtx"
 )
 
 func init() {
@@ -16,7 +17,7 @@ func init() {
 }
 
 func TestCaptureLog(t *testing.T) {
-	out := logx.CaptureLog(nil, func() {
+	out, err := logx.CaptureLog(nil, func() {
 		logger := logx.NewLogEvery(nil, time.Millisecond)
 		start := time.Now()
 		log.Println("key phrase")
@@ -24,6 +25,7 @@ func TestCaptureLog(t *testing.T) {
 			logger.Println(time.Now())
 		}
 	})
+	rtx.Must(err, "Error capturing log")
 
 	if !strings.Contains(out, "logx_test.go:") {
 		t.Error("Missing short filename")
@@ -36,13 +38,14 @@ func TestCaptureLog(t *testing.T) {
 
 func TestLogEvery_Println(t *testing.T) {
 	logger := log.New(os.Stderr, "", log.LstdFlags|log.Lshortfile)
-	out := logx.CaptureLog(logger, func() {
+	out, err := logx.CaptureLog(logger, func() {
 		logger := logx.NewLogEvery(logger, time.Millisecond)
 		start := time.Now()
 		for ; time.Since(start) < 10*time.Millisecond; time.Sleep(100 * time.Microsecond) {
 			logger.Println("foobar")
 		}
 	})
+	rtx.Must(err, "Error capturing log")
 
 	if !strings.Contains(out, "logx.go:") {
 		t.Error("Missing short filename")
@@ -59,13 +62,14 @@ func TestLogEvery_Println(t *testing.T) {
 
 func TestLogEvery_Printf(t *testing.T) {
 	logger := log.New(os.Stderr, "", log.LstdFlags|log.Lshortfile)
-	out := logx.CaptureLog(logger, func() {
+	out, err := logx.CaptureLog(logger, func() {
 		logger := logx.NewLogEvery(logger, time.Millisecond)
 		start := time.Now()
 		for ; time.Since(start) < 10*time.Millisecond; time.Sleep(100 * time.Microsecond) {
 			logger.Printf("%s\n", "foobar")
 		}
 	})
+	rtx.Must(err, "Error capturing log")
 
 	if !strings.Contains(out, "logx.go:") {
 		t.Error("Missing short filename")

--- a/logx/logx_test.go
+++ b/logx/logx_test.go
@@ -2,6 +2,7 @@ package logx_test
 
 import (
 	"log"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -15,8 +16,8 @@ func init() {
 }
 
 func TestCaptureLog(t *testing.T) {
-	out := logx.CaptureLog(func() {
-		logger := logx.NewLogEvery(time.Millisecond)
+	out := logx.CaptureLog(nil, func() {
+		logger := logx.NewLogEvery(nil, time.Millisecond)
 		start := time.Now()
 		log.Println("key phrase")
 		for time.Since(start) < 10*time.Millisecond {
@@ -34,8 +35,9 @@ func TestCaptureLog(t *testing.T) {
 }
 
 func TestLogEvery_Println(t *testing.T) {
-	out := logx.CaptureLog(func() {
-		logger := logx.NewLogEvery(time.Millisecond)
+	logger := log.New(os.Stderr, "", log.LstdFlags|log.Lshortfile)
+	out := logx.CaptureLog(logger, func() {
+		logger := logx.NewLogEvery(logger, time.Millisecond)
 		start := time.Now()
 		for ; time.Since(start) < 10*time.Millisecond; time.Sleep(100 * time.Microsecond) {
 			logger.Println("foobar")
@@ -56,8 +58,9 @@ func TestLogEvery_Println(t *testing.T) {
 }
 
 func TestLogEvery_Printf(t *testing.T) {
-	out := logx.CaptureLog(func() {
-		logger := logx.NewLogEvery(time.Millisecond)
+	logger := log.New(os.Stderr, "", log.LstdFlags|log.Lshortfile)
+	out := logx.CaptureLog(logger, func() {
+		logger := logx.NewLogEvery(logger, time.Millisecond)
 		start := time.Now()
 		for ; time.Since(start) < 10*time.Millisecond; time.Sleep(100 * time.Microsecond) {
 			logger.Printf("%s\n", "foobar")

--- a/logx/logx_test.go
+++ b/logx/logx_test.go
@@ -82,4 +82,26 @@ func TestLogEvery_Printf(t *testing.T) {
 	if len(lines) < 9 {
 		t.Error("Too few logs", len(lines))
 	}
+
+	// Test with log.std
+	out, err = logx.CaptureLog(nil, func() {
+		logger := logx.NewLogEvery(nil, time.Millisecond)
+		start := time.Now()
+		for ; time.Since(start) < 10*time.Millisecond; time.Sleep(100 * time.Microsecond) {
+			logger.Printf("%s\n", "foobar")
+		}
+	})
+	rtx.Must(err, "Error capturing log")
+
+	if !strings.Contains(out, "logx.go:") {
+		t.Error("Missing short filename")
+	}
+	lines = strings.Split(out, "\n")
+	// Should be 10 or 11.  Error if more than 12.
+	if len(lines) > 12 {
+		t.Error("Too many logs", len(lines))
+	}
+	if len(lines) < 9 {
+		t.Error("Too few logs", len(lines))
+	}
 }


### PR DESCRIPTION
This adds two utility functions. 

CaptureLog allows capturing everything written to the log, to facilitate testing.

NewLogEvery creates a logger that limits the frequency of logging.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/go/52)
<!-- Reviewable:end -->
