### PR TITLE
Improve rtx.Must log messages

### DIFF
--- a/rtx/rtx.go
+++ b/rtx/rtx.go
@@ -5,10 +5,11 @@ package rtx
 import (
 	"fmt"
 	"log"
+	"os"
 )
 
 // Allow overriding of this variable to aid in whitebox testing.
-var logFatal = log.Fatal
+var osExit = os.Exit
 
 // Must will call log.Fatal if passed a non-nil error. The fatal message is
 // specified as the prefix argument. If any further args are passed, then the
@@ -27,11 +28,12 @@ var logFatal = log.Fatal
 // coverage.
 func Must(err error, prefix string, args ...interface{}) {
 	if err != nil {
-		suffix := fmt.Sprintf("(error: %v)", err)
+		suffix := fmt.Sprintf(" (error: %v)", err)
 		if len(args) != 0 {
 			prefix = fmt.Sprintf(prefix, args...)
 		}
-		logFatal(prefix, suffix)
+		log.Output(2, prefix+suffix)
+		osExit(1)
 	}
 }
 
@@ -55,6 +57,7 @@ func PanicOnError(err error, prefix string, args ...interface{}) {
 		if len(args) != 0 {
 			prefix = fmt.Sprintf(prefix, args...)
 		}
+		log.Output(2, prefix+suffix)
 		panic(prefix + suffix)
 	}
 }


### PR DESCRIPTION
Use Output to refer to the line that called Must(). Log messages should now be much improved.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/go/58)
<!-- Reviewable:end -->
