### PR TITLE
Add GCSClient for storage testing

### DIFF
--- a/cloudtest/gcs.go
+++ b/cloudtest/gcs.go
@@ -1,0 +1,67 @@
+package cloudtest
+
+import (
+	"context"
+	"strings"
+
+	"cloud.google.com/go/storage"
+	"github.com/GoogleCloudPlatform/google-cloud-go-testing/storage/stiface"
+	"google.golang.org/api/iterator"
+)
+
+type GCSClient struct {
+	stiface.Client
+	buckets map[string]BucketHandle
+}
+
+func (c *GCSClient) AddTestBucket(name string, bh BucketHandle) {
+	if c.buckets == nil {
+		c.buckets = make(map[string]BucketHandle, 5)
+	}
+	c.buckets[name] = bh
+}
+
+func (c GCSClient) Close() error {
+	return nil
+}
+
+func (c GCSClient) Bucket(name string) stiface.BucketHandle {
+	return c.buckets[name]
+}
+
+type BucketHandle struct {
+	stiface.BucketHandle
+	ObjAttrs []*storage.ObjectAttrs // Objects that will be returned by iterator
+}
+
+func (bh BucketHandle) Attrs(ctx context.Context) (*storage.BucketAttrs, error) {
+	return &storage.BucketAttrs{}, nil
+}
+
+func (bh BucketHandle) Objects(ctx context.Context, q *storage.Query) stiface.ObjectIterator {
+	// TODO - should check if ctx has expired?
+	obj := make([]*storage.ObjectAttrs, 0, len(bh.ObjAttrs))
+	for i := range bh.ObjAttrs {
+		if strings.HasPrefix(bh.ObjAttrs[i].Name, q.Prefix) {
+			obj = append(obj, bh.ObjAttrs[i])
+		}
+	}
+	n := 0
+	return objIt{next: &n, objects: obj}
+}
+
+type objIt struct {
+	stiface.ObjectIterator
+	objects []*storage.ObjectAttrs
+	next    *int
+}
+
+func (it objIt) Next() (*storage.ObjectAttrs, error) {
+	if *it.next >= len(it.objects) {
+		return nil, iterator.Done
+	}
+	*it.next++
+	return it.objects[*it.next-1], nil
+}
+
+func assertStifaceClient() { func(c stiface.Client) {}(&GCSClient{}) }

--- a/cloudtest/gcs.go
+++ b/cloudtest/gcs.go
@@ -1,3 +1,19 @@
+//  Copyright 2017 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package cloudtest provides utilities for testing, e.g. cloud
+// service tests using mock http Transport, fake storage client, etc.
 package cloudtest
 
 import (

--- a/cloudtest/gcs_test.go
+++ b/cloudtest/gcs_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/storage"
+	"github.com/GoogleCloudPlatform/google-cloud-go-testing/storage/stiface"
 	"github.com/m-lab/go/cloudtest"
 	"google.golang.org/api/iterator"
 )
@@ -14,6 +15,28 @@ import (
 func init() {
 	// Always prepend the filename and line number.
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
+}
+
+func countAll(t *testing.T, it stiface.ObjectIterator) (total int, normal int, prefix int) {
+	for o, err := it.Next(); err != iterator.Done; o, err = it.Next() {
+		if err != nil {
+			t.Fatal(err, "when attempting it.Next()")
+			continue
+		}
+
+		total++
+
+		if o.Prefix != "" {
+			prefix++
+			log.Println("Skipping", o.Prefix)
+			continue
+		}
+		if o.Updated.Before(time.Now().Add(-time.Minute)) {
+			continue
+		}
+		normal++
+	}
+	return
 }
 
 func TestGCSClient(t *testing.T) {
@@ -27,7 +50,9 @@ func TestGCSClient(t *testing.T) {
 				&storage.ObjectAttrs{Name: "ndt/2019/01/01/obj1", Updated: time.Now()},
 				&storage.ObjectAttrs{Name: "ndt/2019/01/01/obj2", Updated: time.Now()},
 				&storage.ObjectAttrs{Name: "ndt/2019/01/01/obj3"},
-				&storage.ObjectAttrs{Name: "obj4", Updated: time.Now()},
+				&storage.ObjectAttrs{Name: "ndt/2019/01/01/subdir/obj4", Updated: time.Now()},
+				&storage.ObjectAttrs{Name: "ndt/2019/01/01/subdir/obj5", Updated: time.Now()},
+				&storage.ObjectAttrs{Name: "obj6", Updated: time.Now()},
 			}})
 
 	bucket := fc.Bucket("foobar")
@@ -43,32 +68,45 @@ func TestGCSClient(t *testing.T) {
 
 	qry := storage.Query{
 		Delimiter: "/",
-		Prefix:    "ndt/2019/01/01",
+		Prefix:    "ndt/2019/01/01/",
 	}
 	it := bucket.Objects(ctx, &qry)
 
-	count := 0
-	for o, err := it.Next(); err != iterator.Done; o, err = it.Next() {
-		if err != nil {
-			// TODO - should this retry?
-			// log the underlying error, with added context
-			t.Error(err, "when attempting it.Next()")
-			continue
-		}
+	_, n, p := countAll(t, it)
+	if n != 2 {
+		t.Error("Expected 2 items, got", n)
+	}
+	if p != 1 {
+		t.Error("Expected 1 prefix, got", p)
+	}
 
-		if o.Prefix != "" {
-			log.Println("Skipping", o.Prefix)
-			continue
-		}
-		if o.Updated.Before(time.Now().Add(-time.Minute)) {
-			continue
-		}
-		log.Println(o.Name)
-		count++
+	qry = storage.Query{
+		Delimiter: "/",
+		Prefix:    "ndt/2019/01/01",
 	}
-	if count != 2 {
-		t.Error("Expected 2 items", count)
+	it = bucket.Objects(ctx, &qry)
+
+	_, n, p = countAll(t, it)
+	if n != 2 {
+		t.Error("Expected 2 items, got", n)
 	}
+	if p != 1 {
+		t.Error("Expected 1 prefix, got", p)
+	}
+
+	qry = storage.Query{
+		Delimiter: "/",
+		Prefix:    "ndt/2019/01/01/obj",
+	}
+	it = bucket.Objects(ctx, &qry)
+
+	_, n, p = countAll(t, it)
+	if n != 2 {
+		t.Error("Expected 2 items, got", n)
+	}
+	if p != 0 {
+		t.Error("Expected 0 prefix, got", p)
+	}
+
 	fc.Close()
-	t.Fail()
 }

--- a/cloudtest/gcs_test.go
+++ b/cloudtest/gcs_test.go
@@ -1,0 +1,74 @@
+package cloudtest_test
+
+import (
+	"context"
+	"log"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/storage"
+	"github.com/m-lab/go/cloudtest"
+	"google.golang.org/api/iterator"
+)
+
+func init() {
+	// Always prepend the filename and line number.
+	log.SetFlags(log.LstdFlags | log.Lshortfile)
+}
+
+func TestGCSClient(t *testing.T) {
+	// Use a fake queue client.
+	ctx := context.Background()
+
+	fc := cloudtest.GCSClient{}
+	fc.AddTestBucket("foobar",
+		cloudtest.BucketHandle{
+			ObjAttrs: []*storage.ObjectAttrs{
+				&storage.ObjectAttrs{Name: "ndt/2019/01/01/obj1", Updated: time.Now()},
+				&storage.ObjectAttrs{Name: "ndt/2019/01/01/obj2", Updated: time.Now()},
+				&storage.ObjectAttrs{Name: "ndt/2019/01/01/obj3"},
+				&storage.ObjectAttrs{Name: "obj4", Updated: time.Now()},
+			}})
+
+	bucket := fc.Bucket("foobar")
+	if bucket == nil {
+		t.Fatal("Bucket is nil")
+	}
+	// Check that the bucket is valid, by fetching it's attributes.
+	// Bypass check if we are running travis tests.
+	_, err := bucket.Attrs(ctx)
+	if err != nil {
+		t.Error(err)
+	}
+
+	qry := storage.Query{
+		Delimiter: "/",
+		Prefix:    "ndt/2019/01/01",
+	}
+	it := bucket.Objects(ctx, &qry)
+
+	count := 0
+	for o, err := it.Next(); err != iterator.Done; o, err = it.Next() {
+		if err != nil {
+			// TODO - should this retry?
+			// log the underlying error, with added context
+			t.Error(err, "when attempting it.Next()")
+			continue
+		}
+
+		if o.Prefix != "" {
+			log.Println("Skipping", o.Prefix)
+			continue
+		}
+		if o.Updated.Before(time.Now().Add(-time.Minute)) {
+			continue
+		}
+		log.Println(o.Name)
+		count++
+	}
+	if count != 2 {
+		t.Error("Expected 2 items", count)
+	}
+	fc.Close()
+	t.Fail()
+}

--- a/cloudtest/gcs_test.go
+++ b/cloudtest/gcs_test.go
@@ -68,46 +68,31 @@ func TestGCSClient(t *testing.T) {
 		t.Error(err)
 	}
 
-	qry := storage.Query{
-		Delimiter: "/",
-		Prefix:    "ndt/2019/01/01/",
+	type test struct {
+		prefix string
+		n      int
+		p      int
 	}
-	it := bucket.Objects(ctx, &qry)
-
-	_, n, p := countAll(t, it)
-	if n != 2 {
-		t.Error("Expected 2 items, got", n)
-	}
-	if p != 1 {
-		t.Error("Expected 1 prefix, got", p)
+	tests := []test{
+		{"ndt/2019/01/01", 2, 1},
+		{"ndt/2019/01/01/", 2, 1},
+		{"ndt/2019/01/01/obj", 2, 0},
 	}
 
-	qry = storage.Query{
-		Delimiter: "/",
-		Prefix:    "ndt/2019/01/01",
-	}
-	it = bucket.Objects(ctx, &qry)
+	for _, tt := range tests {
+		qry := storage.Query{
+			Delimiter: "/",
+			Prefix:    tt.prefix,
+		}
+		it := bucket.Objects(ctx, &qry)
 
-	_, n, p = countAll(t, it)
-	if n != 2 {
-		t.Error("Expected 2 items, got", n)
-	}
-	if p != 1 {
-		t.Error("Expected 1 prefix, got", p)
-	}
-
-	qry = storage.Query{
-		Delimiter: "/",
-		Prefix:    "ndt/2019/01/01/obj",
-	}
-	it = bucket.Objects(ctx, &qry)
-
-	_, n, p = countAll(t, it)
-	if n != 2 {
-		t.Error("Expected 2 items, got", n)
-	}
-	if p != 0 {
-		t.Error("Expected 0 prefix, got", p)
+		_, n, p := countAll(t, it)
+		if n != tt.n {
+			t.Error("Expected", tt.n, "items, got", n)
+		}
+		if p != tt.p {
+			t.Error("Expected", tt.p, "prefix, got", p)
+		}
 	}
 
 	fc.Close()

--- a/cloudtest/gcs_test.go
+++ b/cloudtest/gcs_test.go
@@ -51,10 +51,10 @@ func TestGCSClient(t *testing.T) {
 			ObjAttrs: []*storage.ObjectAttrs{
 				&storage.ObjectAttrs{Name: "ndt/2019/01/01/obj1", Updated: time.Now()},
 				&storage.ObjectAttrs{Name: "ndt/2019/01/01/obj2", Updated: time.Now()},
-				&storage.ObjectAttrs{Name: "ndt/2019/01/01/obj3"},
-				&storage.ObjectAttrs{Name: "ndt/2019/01/01/subdir/obj4", Updated: time.Now()},
+				&storage.ObjectAttrs{Name: "ndt/2019/01/01/obj3"},                             // Will be filtered out by the "since" filter.
+				&storage.ObjectAttrs{Name: "ndt/2019/01/01/subdir/obj4", Updated: time.Now()}, // filtered because of subdir.
 				&storage.ObjectAttrs{Name: "ndt/2019/01/01/subdir/obj5", Updated: time.Now()},
-				&storage.ObjectAttrs{Name: "obj6", Updated: time.Now()},
+				&storage.ObjectAttrs{Name: "obj6", Updated: time.Now()}, // Will be filtered by prefix.
 			}})
 
 	bucket := fc.Bucket("foobar")
@@ -74,9 +74,9 @@ func TestGCSClient(t *testing.T) {
 		p      int
 	}
 	tests := []test{
-		{"ndt/2019/01/01", 2, 1},
-		{"ndt/2019/01/01/", 2, 1},
-		{"ndt/2019/01/01/obj", 2, 0},
+		{"ndt/2019/01/01", 2, 1},     // Prefix that is a directory, but without the final /
+		{"ndt/2019/01/01/", 2, 1},    // Should work both with and without slash.
+		{"ndt/2019/01/01/obj", 2, 0}, // Should work with a prefix that isn't a directory.
 	}
 
 	for _, tt := range tests {

--- a/cloudtest/gcs_test.go
+++ b/cloudtest/gcs_test.go
@@ -17,6 +17,8 @@ func init() {
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
 }
 
+func assertStifaceClient() { func(c stiface.Client) {}(&cloudtest.GCSClient{}) }
+
 func countAll(t *testing.T, it stiface.ObjectIterator) (total int, normal int, prefix int) {
 	for o, err := it.Next(); err != iterator.Done; o, err = it.Next() {
 		if err != nil {

--- a/cloudtest/http.go
+++ b/cloudtest/http.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 // Package cloudtest provides utilities for testing, e.g. cloud
-// service tests using mock http Transport.
+// service tests using mock http Transport, fake storage client, etc.
 package cloudtest
 
 import (


### PR DESCRIPTION
This adds a simple fake client that can be customized to return arbitrary objects.  It supports simple query that returns an iterator with appropriate files.

It does not currently allow changing the buckets, aside from replacing one altogether.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/go/60)
<!-- Reviewable:end -->
