### PR TITLE
Add support for CustomAppend operation

### DIFF
--- a/bqx/schema_test.go
+++ b/bqx/schema_test.go
@@ -81,6 +81,25 @@ func TestCustomize(t *testing.T) {
 	expect(t, c, `"RECORD"`, 1)
 }
 
+func TestCustomizeAppend(t *testing.T) {
+	type inner struct {
+		Control Embedded
+	}
+	type outer struct {
+		Outer        inner
+		Timestamp    time.Time
+		IntTimestamp int64 // `bigquery:"-"`
+	}
+	s, err := bigquery.InferSchema(outer{})
+	rtx.Must(err, "")
+
+	subs := map[string]*bigquery.FieldSchema{
+		"Control": &bigquery.FieldSchema{Name: "AddedInteger", Description: "", Repeated: false, Required: true, Type: "INTEGER"},
+	}
+	c := bqx.CustomizeAppend(s, subs)  // Append AddedInterger to the inner Control field.
+	expect(t, c, `"Required":true`, 7) // The original struct has 6, and we add 1 more
+	expect(t, c, `"RECORD"`, 2)        // The Outer and Control fields are both RECORD types.
+}
 func TestPrettyPrint(t *testing.T) {
 	expected :=
 		`[


### PR DESCRIPTION
Part of https://github.com/m-lab/etl/issues/719

In order to "fix" bigquery schemas derived from structs that have field types not natively supported by bigquery, we need to be able to add new schema fields in their place.

This change builds on the existing `Customize` function to allow new schema fields to be appended to inner records. This will be first used to change `map[string]string` types to `[]NameValue`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/go/61)
<!-- Reviewable:end -->
