### PR TITLE
Add a Ticker struct to memoryless.

### DIFF
--- a/memoryless/memoryless.go
+++ b/memoryless/memoryless.go
@@ -13,6 +13,8 @@ import (
 //
 // A valid config will have:
 //  0 <= Min <= Expected <= Max (or 0 <= Min <= Expected and Max is 0)
+// If Max is zero or unset, it will be ignored. If Min is zero or unset, it will
+// be ignored.
 type Config struct {
 	// Expected records the expected/mean/average amount of time between runs.
 	Expected time.Duration
@@ -42,60 +44,118 @@ func (c Config) waittime() time.Duration {
 	return wt
 }
 
-// Run calls the given function repeatedly, waiting a c.Expected amount of time
-// between calls on average. The wait time is actually random and will generate
-// a memoryless (Poisson) distribution of f() calls in time, ensuring that f()
-// has the PASTA property (Poisson Arrivals See Time Averages). This statistical
-// guarantee is subject to two caveats.
+// Ticker is a struct that waits a config.Expected amount of time on average
+// between sends down the channel C. It has the same interface and requirements
+// as time.Ticker. Every Ticker created must have its Stop() method called or it
+// will leak a goroutine.
+//
+// The inter-send time is actually random and will generate a memoryless
+// (Poisson) distribution of channel reads over time, ensuring that a
+// measurement scheme using this ticker has the PASTA property (Poisson Arrivals
+// See Time Averages). This statistical guarantee is subject to two caveats:
 //
 // Caveat 1 is that, in a nod to the realities of systems needing to have
 // guarantees, we allow the random wait time to be clamped both above and below.
-// This means that calls to f() should be at least c.Min and at most c.Max apart
-// in time. This clamping causes bias in the timing. For use of this function to
-// be statistically sensible, the clamping should not be too extreme. The exact
-// mathematical meaning of "too extreme" depends on your situation, but a nice
-// rule of thumb is c.Min should be at most 10% of expected and c.Max should be
-// at least 250% of expected. These values mean that less than 10% of time you
-// will be waiting c.Min and less than 10% of the time you will be waiting
-// c.Max.
+// This means that channel events should be at least c.Min and at most c.Max
+// apart in time. This clamping causes bias in the timing. For use of this
+// function to be statistically sensible, the clamping should not be too
+// extreme. The exact mathematical meaning of "too extreme" depends on your
+// situation, but a nice rule of thumb is config.Min should be at most 10% of
+// expected and config.Max should be at least 250% of expected. These values
+// mean that less than 10% of time you will be waiting config.Min and less than
+// 10% of the time you will be waiting config.Max.
 //
-// Caveat 2 is that this assumes that the function f() takes negligible time to
-// run when compared to the expected wait time. Technically memoryless events
-// have the property that the times between successive event starts has the
-// exponential distribution, and this code will not start a new call to f()
-// before the old one has completed, which provides a lower bound on wait times.
-func Run(ctx context.Context, f func(), c Config) error {
-	if !(0 <= c.Min && c.Min <= c.Expected && (c.Max == 0 || c.Expected <= c.Max)) {
-		return fmt.Errorf(
-			"The arguments to Run make no sense. It should be true that Min <= Expected <= Max (or Min <= Expected and Max is 0), "+
-				"but that is not true for Min(%v) Expected(%v) Max(%v).",
-			c.Min, c.Expected, c.Max)
+// Caveat 2 is that this assumes that the measurements being performed take
+// negligible time to run when compared to the expected wait time. Technically,
+// memoryless events have the property that the times between successive event
+// starts has the exponential distribution, and this code will not send on the
+// channel if the other end is not ready to receive, which provides a lower
+// bound on wait times.
+type Ticker struct {
+	C         <-chan time.Time // The channel on which the ticks are delivered.
+	config    Config
+	writeChan chan<- time.Time
+	cancel    func()
+}
+
+func (t *Ticker) runTicker(ctx context.Context) {
+	// No matter what, when this function exits the channel should never be written to again.
+	defer close(t.writeChan)
+
+	if t.config.Once {
+		if ctx.Err() == nil {
+			t.writeChan <- time.Now()
+		}
+		return
 	}
-	if c.Once {
-		f()
-		return nil
-	}
+
 	// When Done() is not closed and the Deadline has not been exceeded, the error
 	// is nil.
 	for ctx.Err() == nil {
-		// Start the timer before the function call because the time between function
-		// call *starts* should be exponentially distributed.
-		t := time.NewTimer(c.waittime())
-		f()
+		timer := time.NewTimer(t.config.waittime())
+		// Just like time.Ticker, writes to the channel are non-blocking. If a user of
+		// this module can't keep up with the timer they set, that's on them. There
+		// are some potential pathological cases associated with queueing events in
+		// the channel, and we want to avoid them.
+		select {
+		case t.writeChan <- time.Now():
+		default:
+		}
 		// Wait until the timer is done or the context is canceled. If both conditions
 		// are true, which case gets called is unspecified.
 		select {
 		case <-ctx.Done():
-			// Clean up the timer.
-			t.Stop()
-			// Please don't put logic here that assumes that this code path will
+			// Clean up the timer - not strictly required, but nice to do.
+			timer.Stop()
+			// Please don't put code here that assumes that this code path will
 			// definitely execute if the context is done. select {} doesn't promise that
 			// multiple channels will get selected with equal probability, which means
-			// that if f() takes a while and c.Max is low, then it could be true that the
-			// timer is done AND the context is canceled, and we have no guarantee that
-			// in that case the canceled context case will be the one that is selected.
-		case <-t.C:
+			// that if the channel write takes long enough and c.Max is low enough, then
+			// it could be true that the timer is done AND the context is canceled, and
+			// we have no guarantee that in that case the canceled context case will be
+			// the one that is selected.
+		case <-timer.C:
 		}
+	}
+}
+
+// Stop the ticker goroutine.
+func (t *Ticker) Stop() {
+	t.cancel()
+}
+
+// MakeTicker creates a new memoryless ticker. The returned struct is compatible
+// with the time.Ticker struct interface, and everywhere you use a time.Ticker,
+// you can use a memoryless.Ticker.
+func MakeTicker(ctx context.Context, config Config) (*Ticker, error) {
+	if !(0 <= config.Min && config.Min <= config.Expected && (config.Max == 0 || config.Expected <= config.Max)) {
+		return nil, fmt.Errorf(
+			"The arguments to Run make no sense. It should be true that Min <= Expected <= Max (or Min <= Expected and Max is 0), "+
+				"but that is not true for Min(%v) Expected(%v) Max(%v).",
+			config.Min, config.Expected, config.Max)
+	}
+	c := make(chan time.Time)
+	ctx, cancel := context.WithCancel(ctx)
+	ticker := &Ticker{
+		C:         c,
+		config:    config,
+		writeChan: c,
+		cancel:    cancel,
+	}
+	go ticker.runTicker(ctx)
+	return ticker, nil
+}
+
+// Run calls the given function repeatedly, using a memoryless.Ticker to wait
+// between function calls.
+func Run(ctx context.Context, f func(), c Config) error {
+	ticker, err := MakeTicker(ctx, c)
+	if err != nil {
+		return err
+	}
+	defer ticker.Stop()
+	for range ticker.C {
+		f()
 	}
 	return nil
 }

--- a/memoryless/memoryless_test.go
+++ b/memoryless/memoryless_test.go
@@ -60,3 +60,18 @@ func TestRunForever(t *testing.T) {
 	// If this does not run forever, then f() was called at least 100 times and
 	// then the context was canceled.
 }
+
+func TestLongRunningFunctions(t *testing.T) {
+	wt := time.Duration(1 * time.Microsecond)
+	ticker, err := memoryless.MakeTicker(context.Background(), memoryless.Config{Expected: wt, Min: wt, Max: wt})
+	rtx.Must(err, "Could not make ticker")
+	time.Sleep(time.Millisecond)
+	ticker.Stop()
+	count := 0
+	for range ticker.C {
+		count++
+	}
+	if count > 0 {
+		t.Errorf("There should have been nothing in the channel, but instead there were %d items", count)
+	}
+}


### PR DESCRIPTION
This allows package users to use it just like a `time.Ticker`, which makes everyone's life easier.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/go/62)
<!-- Reviewable:end -->
