### PR TITLE
Add WalkSchema and UpdateSchemaDescription functions

### DIFF
--- a/bqx/schema.go
+++ b/bqx/schema.go
@@ -275,13 +275,13 @@ func UpdateSchemaDescription(schema bigquery.Schema, docs SchemaDoc) error {
 		schema, func(prefix []string, field *bigquery.FieldSchema) error {
 			var ok bool
 			var d map[string]string
-			// Starting with the longest prefix, stop looking or descriptions on first match.
-			for window := len(prefix); window != 0 && !ok; window-- {
-				path := strings.Join(prefix[len(prefix)-window:], ".")
+			// Starting with the longest prefix, stop looking for descriptions on first match.
+			for start := 0; start < len(prefix) && !ok; start++ {
+				path := strings.Join(prefix[start:], ".")
 				d, ok = docs[path]
 			}
 			if !ok {
-				// This is not an error, the field simply doen't have extra description.
+				// This is not an error, the field simply doesn't have extra description.
 				return nil
 			}
 			if field.Description != "" {

--- a/bqx/schema.go
+++ b/bqx/schema.go
@@ -6,11 +6,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"regexp"
 	"strings"
 
 	"cloud.google.com/go/bigquery"
+	"github.com/m-lab/go/rtx"
+	"gopkg.in/yaml.v2"
 )
 
 // PrettyPrint generates a formatted json representation of a Schema.
@@ -248,5 +251,67 @@ func (pdt PDT) CreateTable(ctx context.Context, client *bigquery.Client, schema 
 		return err
 	}
 
+	return nil
+}
+
+// SchemaDoc contains bigquery.Schema field Descriptions as read from an auxiliary source, such as YAML.
+type SchemaDoc map[string]map[string]string
+
+// ReadSchemaDoc reads the given file and attempts to parse it as a SchemaDoc. Errors are fatal.
+func ReadSchemaDoc(file string) SchemaDoc {
+	docs, err := ioutil.ReadFile(file)
+	rtx.Must(err, "Failed to read: %q", file)
+
+	sd := SchemaDoc{}
+	err = yaml.Unmarshal([]byte(docs), &sd)
+	rtx.Must(err, "Failed to unmarshal: %q", file)
+	return sd
+}
+
+// UpdateSchemaDescription walks each field in the given schema and assigns the
+// Description field in place using values found in the given SchemaDoc.
+func UpdateSchemaDescription(schema bigquery.Schema, docs SchemaDoc) error {
+	WalkSchema(
+		schema, func(prefix []string, field *bigquery.FieldSchema) error {
+			var ok bool
+			var d map[string]string
+			// Starting with the longest prefix, stop looking or descriptions on first match.
+			for window := len(prefix); window != 0 && !ok; window-- {
+				path := strings.Join(prefix[len(prefix)-window:], ".")
+				d, ok = docs[path]
+			}
+			if !ok {
+				// This is not an error, the field simply doen't have extra description.
+				return nil
+			}
+			if field.Description != "" {
+				log.Printf("WARNING: Overwriting existing description for %q: %q",
+					field.Name, field.Description)
+			}
+			field.Description = d["Description"]
+			return nil
+		},
+	)
+	return nil
+}
+
+// WalkSchema visits every FieldSchema object in the given schema by calling the visit function.
+// The prefix is a path of field names from the top level to the current Field.
+func WalkSchema(schema bigquery.Schema, visit func(prefix []string, field *bigquery.FieldSchema) error) error {
+	return walkSchema([]string{}, schema, visit)
+}
+
+func walkSchema(prefix []string, schema bigquery.Schema, visit func(prefix []string, field *bigquery.FieldSchema) error) error {
+	fields := ([]*bigquery.FieldSchema)(schema)
+	for _, field := range fields {
+		path := append(prefix, field.Name)
+		err := visit(path, field)
+		if err != nil {
+			return err
+		}
+		if field.Type == bigquery.RecordFieldType {
+			walkSchema(path, field.Schema, visit)
+		}
+	}
 	return nil
 }

--- a/bqx/schema_test.go
+++ b/bqx/schema_test.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"math/rand"
+	"os"
+	"reflect"
 	"runtime"
 	"strconv"
 	"strings"
@@ -13,11 +16,11 @@ import (
 	"testing"
 	"time"
 
+	"cloud.google.com/go/bigquery"
 	"github.com/m-lab/go/bqx"
 	"github.com/m-lab/go/rtx"
 	"google.golang.org/api/googleapi"
-
-	"cloud.google.com/go/bigquery"
+	"src/github.com/kr/pretty"
 )
 
 func init() {
@@ -292,5 +295,97 @@ func TestCreateAndUpdate(t *testing.T) {
 	err = deleteDatasetAndContents(ctx, client, pdt)
 	if err != nil {
 		t.Error(err)
+	}
+}
+
+var schemaDocYaml = `
+Field1:
+  Description: Field1 description without prefix path
+Inner.bigqueryField2:
+  Description: Field2 description using full prefix path
+test_id:
+  Description: Filename of measurement data.
+log_time:
+  Description: Collection time of measurement data.
+`
+
+type localInnerStruct struct {
+	Field1 string // Should map to 'Field1' in doc.
+	Field2 string `bigquery:"bigqueryField2"` // Should map to Inner.bigqueryField2 in doc.
+}
+
+type localOuterStruct struct {
+	TestID  string           `bigquery:"test_id"`  // Should map to test_id in doc.
+	LogTime int64            `bigquery:"log_time"` // Should map to log_time in doc.
+	Inner   localInnerStruct // Should use default (empty) description.
+}
+
+func TestUpdateSchemaDescription(t *testing.T) {
+	schema, err := bigquery.InferSchema(localOuterStruct{})
+	rtx.Must(err, "Failed to get schema from localOuterStruct")
+	tmpfile, err := ioutil.TempFile("", "update-schema")
+	rtx.Must(err, "Failed to create temporary file name")
+	err = ioutil.WriteFile(tmpfile.Name(), []byte(schemaDocYaml), 0644)
+	rtx.Must(err, "Failed to write schema doc")
+	defer os.Remove(tmpfile.Name())
+
+	expected := bigquery.Schema{
+		&bigquery.FieldSchema{
+			Name:        "test_id",
+			Description: "Filename of measurement data.",
+			Required:    true,
+			Type:        "STRING",
+		},
+		&bigquery.FieldSchema{
+			Name:        "log_time",
+			Description: "Collection time of measurement data.",
+			Required:    true,
+			Type:        "INTEGER",
+		},
+		&bigquery.FieldSchema{
+			Name:        "Inner",
+			Description: "",
+			Required:    true,
+			Type:        "RECORD",
+			Schema: bigquery.Schema{
+				&bigquery.FieldSchema{
+					Name:        "Field1",
+					Description: "Field1 description without prefix path",
+					Required:    true,
+					Type:        "STRING",
+				},
+				&bigquery.FieldSchema{
+					Name:        "bigqueryField2",
+					Description: "Field2 description using full prefix path",
+					Required:    true,
+					Type:        "STRING",
+				},
+			},
+		},
+	}
+
+	sd := bqx.ReadSchemaDoc(tmpfile.Name())
+	tests := []struct {
+		name    string
+		schema  bigquery.Schema
+		docs    bqx.SchemaDoc
+		want    bigquery.Schema
+		wantErr bool
+	}{
+		{
+			name:   "success",
+			schema: schema,
+			docs:   sd,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := bqx.UpdateSchemaDescription(tt.schema, tt.docs); (err != nil) != tt.wantErr {
+				t.Errorf("UpdateSchemaDescription() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !reflect.DeepEqual(tt.schema, expected) {
+				t.Errorf("UpdateSchemaDescription() failed to match expected schema %q", pretty.Sprint(expected))
+			}
+		})
 	}
 }

--- a/bqx/schema_test.go
+++ b/bqx/schema_test.go
@@ -17,10 +17,10 @@ import (
 	"time"
 
 	"cloud.google.com/go/bigquery"
+	"github.com/kr/pretty"
 	"github.com/m-lab/go/bqx"
 	"github.com/m-lab/go/rtx"
 	"google.golang.org/api/googleapi"
-	"src/github.com/kr/pretty"
 )
 
 func init() {

--- a/cloud/bqfake/bqfake_test.go
+++ b/cloud/bqfake/bqfake_test.go
@@ -52,13 +52,14 @@ func TestDryRunClient(t *testing.T) {
 
 func TestNewClientErr(t *testing.T) {
 	ctx := context.Background()
+	// opts := []option.ClientOption{option.WithAPIKey("asdf"), option.WithoutAuthentication()}
 	opts := []option.ClientOption{option.WithAPIKey("asdf"), option.WithoutAuthentication()}
 	c, err := bqfake.NewClient(ctx, "fakeProject", opts...)
 	if err == nil {
 		c.Close()
-		t.Fatal("Should return dial error")
-	} else if !strings.Contains(err.Error(), "dialing") {
-		t.Fatal("Should return dial error:", err.Error())
+		t.Fatal("Should return constructing client")
+	} else if !strings.Contains(err.Error(), "constructing client") {
+		t.Fatal("Should return constructing client:", err.Error())
 	}
 }
 

--- a/memoryless/memoryless_test.go
+++ b/memoryless/memoryless_test.go
@@ -62,11 +62,15 @@ func TestRunForever(t *testing.T) {
 }
 
 func TestLongRunningFunctions(t *testing.T) {
+	// Make a ticker that fires many many times.
 	wt := time.Duration(1 * time.Microsecond)
 	ticker, err := memoryless.MakeTicker(context.Background(), memoryless.Config{Expected: wt, Min: wt, Max: wt})
 	rtx.Must(err, "Could not make ticker")
 	time.Sleep(time.Millisecond)
 	ticker.Stop()
+	// Once ticker.Stop is called, lose all races.
+	time.Sleep(100 * time.Millisecond)
+	// Verify that no events are queued.
 	count := 0
 	for range ticker.C {
 		count++


### PR DESCRIPTION
Add new functions to bqx package to fulfill the "BQ Schema Docs" proposal.

This change adds a new data type `bqx.SchemaDoc` and three new functions:

* `bqx.ReadSchemaDoc` that reads a new bqx.SchemaDoc from a YAML file.
* `bqx.WalkSchema` which visits every field in a bigquery.Schema and runs a user-provided function to modify the schema.
* `bqx.UpdateSchemaDescription` uses `bqx.WalkSchema` and a `bqx.SchemaDoc` to update the Description fields o a given schema instance.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/go/69)
<!-- Reviewable:end -->
