### PR TITLE
Create schema doc from bytes not files

### DIFF
--- a/bqx/schema.go
+++ b/bqx/schema.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"regexp"
 	"strings"
@@ -257,14 +256,11 @@ func (pdt PDT) CreateTable(ctx context.Context, client *bigquery.Client, schema 
 // SchemaDoc contains bigquery.Schema field Descriptions as read from an auxiliary source, such as YAML.
 type SchemaDoc map[string]map[string]string
 
-// ReadSchemaDoc reads the given file and attempts to parse it as a SchemaDoc. Errors are fatal.
-func ReadSchemaDoc(file string) SchemaDoc {
-	docs, err := ioutil.ReadFile(file)
-	rtx.Must(err, "Failed to read: %q", file)
-
+// NewSchemaDoc reads the given file and attempts to parse it as a SchemaDoc. Errors are fatal.
+func NewSchemaDoc(docs []byte) SchemaDoc {
 	sd := SchemaDoc{}
-	err = yaml.Unmarshal([]byte(docs), &sd)
-	rtx.Must(err, "Failed to unmarshal: %q", file)
+	err := yaml.Unmarshal(docs, &sd)
+	rtx.Must(err, "Failed to unmarshal schema doc")
 	return sd
 }
 

--- a/bqx/schema_test.go
+++ b/bqx/schema_test.go
@@ -364,7 +364,7 @@ func TestUpdateSchemaDescription(t *testing.T) {
 		},
 	}
 
-	sd := bqx.ReadSchemaDoc(tmpfile.Name())
+	sd := bqx.NewSchemaDoc([]byte(schemaDocYaml))
 	tests := []struct {
 		name    string
 		schema  bigquery.Schema


### PR DESCRIPTION
Requiring field descriptions to be in files constrained the use case from m-lab/etl repo.

This change modifies the bqx SchemaDoc functions to accept bytes rather than files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/go/70)
<!-- Reviewable:end -->
