### PR TITLE
Simplify visit parameters, handle all errors

### DIFF
--- a/bqx/schema_test.go
+++ b/bqx/schema_test.go
@@ -384,7 +384,8 @@ func TestUpdateSchemaDescription(t *testing.T) {
 				t.Errorf("UpdateSchemaDescription() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			if !reflect.DeepEqual(tt.schema, expected) {
-				t.Errorf("UpdateSchemaDescription() failed to match expected schema %q", pretty.Sprint(expected))
+				t.Errorf("UpdateSchemaDescription() failed to match expected schema %s", pretty.Sprint(expected))
+				t.Errorf("UpdateSchemaDescription() failed to match expected schema %s", pretty.Sprint(tt.schema))
 			}
 		})
 	}

--- a/bqx/schema_test.go
+++ b/bqx/schema_test.go
@@ -384,8 +384,8 @@ func TestUpdateSchemaDescription(t *testing.T) {
 				t.Errorf("UpdateSchemaDescription() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			if !reflect.DeepEqual(tt.schema, expected) {
-				t.Errorf("UpdateSchemaDescription() failed to match expected schema %s", pretty.Sprint(expected))
-				t.Errorf("UpdateSchemaDescription() failed to match expected schema %s", pretty.Sprint(tt.schema))
+				t.Errorf("UpdateSchemaDescription() failed to match expected schema; got %s, want %s",
+					pretty.Sprint(tt.schema), pretty.Sprint(expected))
 			}
 		})
 	}


### PR DESCRIPTION
This change simplifies the parameters for the `visit` callback passed to `WalkSchema` and correctly handles an error case previously ignored.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/go/71)
<!-- Reviewable:end -->
