### PR TITLE
Set lowest bound on logx test

### DIFF
--- a/logx/logx_test.go
+++ b/logx/logx_test.go
@@ -71,7 +71,7 @@ func TestLogEvery_Println(t *testing.T) {
 	if len(lines) > 12 {
 		t.Error("Too many logs", len(lines))
 	}
-	if len(lines) < 9 {
+	if len(lines) == 0 {
 		t.Error("Too few logs", len(lines))
 	}
 }
@@ -95,7 +95,7 @@ func TestLogEvery_Printf(t *testing.T) {
 	if len(lines) > 12 {
 		t.Error("Too many logs", len(lines))
 	}
-	if len(lines) < 9 {
+	if len(lines) == 0 {
 		t.Error("Too few logs", len(lines))
 	}
 
@@ -117,7 +117,7 @@ func TestLogEvery_Printf(t *testing.T) {
 	if len(lines) > 12 {
 		t.Error("Too many logs", len(lines))
 	}
-	if len(lines) < 9 {
+	if len(lines) == 0 {
 		t.Error("Too few logs", len(lines))
 	}
 }


### PR DESCRIPTION
The logx unit tests were flaky, disrupting regular builds of the m-lab/go repo.

The unit tests are flaky because the logic under test and the test logic both rely on timestamps and sub-millisecond resolutions, making them vulnerable to scheduler and context switching delays. Over ~7000 local runs of the unit test, `len(lines)` equal every value from 2 to 11 at least once.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/go/72)
<!-- Reviewable:end -->
