### PR TITLE
Add dsfake.Client minimal fake datastore client

### DIFF
--- a/cloudtest/dsfake/dsfake.go
+++ b/cloudtest/dsfake/dsfake.go
@@ -1,0 +1,110 @@
+// Package dsfake implements a fake dsiface.Client
+// If you make changes to existing code, please test whether it breaks
+// existing clients, e.g. in etl-gardener.
+package dsfake
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"log"
+	"reflect"
+	"sync"
+
+	"cloud.google.com/go/datastore"
+	"github.com/GoogleCloudPlatform/google-cloud-go-testing/datastore/dsiface"
+)
+
+// NOTE: This is over-restrictive, but fine for current purposes.
+func validateDatastoreEntity(e interface{}) error {
+	v := reflect.ValueOf(e)
+	if v.Kind() != reflect.Ptr {
+		return datastore.ErrInvalidEntityType
+	}
+	// NOTE: This is over-restrictive, but fine for current purposes.
+	if reflect.Indirect(v).Kind() != reflect.Struct {
+		return datastore.ErrInvalidEntityType
+	}
+	return nil
+}
+
+// ErrNotImplemented is returned if a dsiface function is unimplemented.
+var ErrNotImplemented = errors.New("Not implemented")
+
+// Client implements a crude datastore test client.  It is somewhat
+// simplistic and incomplete.  It works only for basic Put, Get, and Delete,
+// but may not always work correctly.
+type Client struct {
+	dsiface.Client // For unimplemented methods
+	lock           sync.Mutex
+	objects        map[datastore.Key]reflect.Value
+}
+
+// NewClient returns a fake client that satisfies dsiface.Client.
+func NewClient() *Client {
+	if flag.Lookup("test.v") == nil {
+		log.Fatal("DSFakeClient should only be used in tests")
+	}
+	return &Client{objects: make(map[datastore.Key]reflect.Value, 10)}
+}
+
+// Close implements dsiface.Client.Close
+func (c *Client) Close() error { return nil }
+
+// Count implements dsiface.Client.Count
+func (c *Client) Count(ctx context.Context, q *datastore.Query) (n int, err error) {
+	return 0, ErrNotImplemented
+}
+
+// Delete implements dsiface.Client.Delete
+func (c *Client) Delete(ctx context.Context, key *datastore.Key) error {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	_, ok := c.objects[*key]
+	if !ok {
+		return datastore.ErrNoSuchEntity
+	}
+	delete(c.objects, *key)
+	return nil
+}
+
+// Get implements dsiface.Client.Get
+func (c *Client) Get(ctx context.Context, key *datastore.Key, dst interface{}) (err error) {
+	err = validateDatastoreEntity(dst)
+	if err != nil {
+		return err
+	}
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	v := reflect.ValueOf(dst)
+	o, ok := c.objects[*key]
+	if !ok {
+		return datastore.ErrNoSuchEntity
+	}
+	v.Elem().Set(o)
+	return nil
+}
+
+// Put mplements dsiface.Client.Put
+func (c *Client) Put(ctx context.Context, key *datastore.Key, src interface{}) (*datastore.Key, error) {
+	err := validateDatastoreEntity(src)
+	if err != nil {
+		return nil, err
+	}
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	v := reflect.ValueOf(src)
+	c.objects[*key] = reflect.Indirect(v)
+	return key, nil
+}
+
+// DumpKeys lists all keys saved in the fake client.
+func (c *Client) DumpKeys() {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	log.Println(len(c.objects), "keys")
+	for k := range c.objects {
+		log.Println("Key:", k)
+	}
+
+}

--- a/cloudtest/dsfake/dsfake.go
+++ b/cloudtest/dsfake/dsfake.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"flag"
+	"fmt"
 	"log"
 	"reflect"
 	"sync"
@@ -81,7 +82,7 @@ func (c *Client) Get(ctx context.Context, key *datastore.Key, dst interface{}) (
 	if !ok {
 		return datastore.ErrNoSuchEntity
 	}
-	v.Elem().Set(o)
+	reflect.Indirect(v).Set(o)
 	return nil
 }
 
@@ -99,12 +100,16 @@ func (c *Client) Put(ctx context.Context, key *datastore.Key, src interface{}) (
 }
 
 // DumpKeys lists all keys saved in the fake client.
-func (c *Client) DumpKeys() {
+func (c *Client) DumpKeys() []datastore.Key {
 	c.lock.Lock()
 	defer c.lock.Unlock()
-	log.Println(len(c.objects), "keys")
-	for k := range c.objects {
-		log.Println("Key:", k)
+	keys := make([]datastore.Key, len(c.objects))
+	i := 0
+	for k, v := range c.objects {
+		keys[i] = k
+		i++
+		log.Output(2, fmt.Sprint(k, v))
 	}
 
+	return keys
 }

--- a/cloudtest/dsfake/dsfake.go
+++ b/cloudtest/dsfake/dsfake.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"errors"
 	"flag"
-	"fmt"
 	"log"
 	"reflect"
 	"sync"
@@ -101,16 +100,15 @@ func (c *Client) Put(ctx context.Context, key *datastore.Key, src interface{}) (
 	return key, nil
 }
 
-// DumpKeys lists all keys saved in the fake client.
-func (c *Client) DumpKeys() []datastore.Key {
+// GetKeys lists all keys saved in the fake client.
+func (c *Client) GetKeys() []datastore.Key {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 	keys := make([]datastore.Key, len(c.objects))
 	i := 0
-	for k, v := range c.objects {
+	for k := range c.objects {
 		keys[i] = k
 		i++
-		log.Output(2, fmt.Sprint(k, string(v)))
 	}
 
 	return keys

--- a/cloudtest/dsfake/dsfake_test.go
+++ b/cloudtest/dsfake/dsfake_test.go
@@ -27,29 +27,63 @@ type Object struct {
 func TestDSFake(t *testing.T) {
 	client := dsfake.NewClient()
 
-	o := Object{"init"}
-	key := datastore.NameKey("TestDSFake", "misc", nil)
+	a := Object{"first"}
+	key := datastore.NameKey("TestDSFake", "o1", nil)
 	key.Namespace = "dsfake"
+	key2 := datastore.NameKey("TestDSFake", "o2", nil)
+	key2.Namespace = "dsfake"
 
-	_, err := client.Put(nil, key, &o)
+	_, err := client.Put(nil, key, &a)
 	must(t, err)
 
-	var r Object
+	var b Object
 	// This should fail because it r isn't a pointer
-	err = client.Get(nil, key, r)
+	err = client.Get(nil, key, b)
 	if err != datastore.ErrInvalidEntityType {
 		t.Error("Should detect non-pointer")
 	}
 
-	must(t, client.Get(nil, key, &r))
-	if r.Value != o.Value {
+	must(t, client.Get(nil, key, &b))
+	if b.Value != a.Value {
 		t.Fatal("Failed put/get")
 	}
 
+	// A second object should not interfere with the first.
+	// c := Object{"other"} // TODO - reuse b instead to test independence.
+	b.Value = "other"
+	_, err = client.Put(nil, key2, &b)
+	must(t, err)
+	client.DumpKeys()
+
+	b.Value = ""
+	must(t, client.Get(nil, key, &b))
+	if b.Value != a.Value {
+		t.Fatal("Apparent object collision", a, b)
+	}
+
+	// test DumpKeys
+	keys := client.DumpKeys()
+	if len(keys) != 2 {
+		t.Fatal("Should be 2 keys")
+	}
+	if keys[0] != *key && keys[1] != *key {
+		t.Error("Missing key", key)
+	}
+	if keys[0] != *key2 && keys[1] != *key2 {
+		t.Error("Missing key", key2)
+	}
+
 	must(t, client.Delete(nil, key))
-	err = client.Get(nil, key, &r)
+	err = client.Get(nil, key, &a)
 	if err != datastore.ErrNoSuchEntity {
 		t.Fatal("delete failed")
+	}
+
+	var c Object
+	// key2 object should still exist
+	must(t, client.Get(nil, key2, &c))
+	if c.Value != "other" {
+		t.Error("Wrong value", c.Value)
 	}
 
 }

--- a/cloudtest/dsfake/dsfake_test.go
+++ b/cloudtest/dsfake/dsfake_test.go
@@ -1,0 +1,55 @@
+package dsfake_test
+
+import (
+	"log"
+	"testing"
+
+	"cloud.google.com/go/datastore"
+	"github.com/m-lab/go/cloudtest/dsfake"
+)
+
+func init() {
+	// Always prepend the filename and line number.
+	log.SetFlags(log.LstdFlags | log.Lshortfile)
+}
+
+func must(t *testing.T, err error) {
+	if err != nil {
+		log.Output(2, err.Error())
+		t.Fatal(err)
+	}
+}
+
+type Object struct {
+	Value string
+}
+
+func TestDSFake(t *testing.T) {
+	client := dsfake.NewClient()
+
+	o := Object{"init"}
+	key := datastore.NameKey("TestDSFake", "misc", nil)
+	key.Namespace = "dsfake"
+
+	_, err := client.Put(nil, key, &o)
+	must(t, err)
+
+	var r Object
+	// This should fail because it r isn't a pointer
+	err = client.Get(nil, key, r)
+	if err != datastore.ErrInvalidEntityType {
+		t.Error("Should detect non-pointer")
+	}
+
+	must(t, client.Get(nil, key, &r))
+	if r.Value != o.Value {
+		t.Fatal("Failed put/get")
+	}
+
+	must(t, client.Delete(nil, key))
+	err = client.Get(nil, key, &r)
+	if err != datastore.ErrNoSuchEntity {
+		t.Fatal("delete failed")
+	}
+
+}

--- a/cloudtest/dsfake/dsfake_test.go
+++ b/cloudtest/dsfake/dsfake_test.go
@@ -27,63 +27,65 @@ type Object struct {
 func TestDSFake(t *testing.T) {
 	client := dsfake.NewClient()
 
-	a := Object{"first"}
-	key := datastore.NameKey("TestDSFake", "o1", nil)
-	key.Namespace = "dsfake"
-	key2 := datastore.NameKey("TestDSFake", "o2", nil)
-	key2.Namespace = "dsfake"
+	k1 := datastore.NameKey("TestDSFake", "o1", nil)
+	k1.Namespace = "dsfake"
+	k2 := datastore.NameKey("TestDSFake", "o2", nil)
+	k2.Namespace = "dsfake"
 
-	_, err := client.Put(nil, key, &a)
+	o1 := Object{"o1"}
+	_, err := client.Put(nil, k1, &o1)
 	must(t, err)
 
-	var b Object
-	// This should fail because it r isn't a pointer
-	err = client.Get(nil, key, b)
+	var o1a Object
+	// This should fail because it o1a isn't a pointer
+	err = client.Get(nil, k1, o1a)
 	if err != datastore.ErrInvalidEntityType {
 		t.Error("Should detect non-pointer")
 	}
 
-	must(t, client.Get(nil, key, &b))
-	if b.Value != a.Value {
-		t.Fatal("Failed put/get")
+	must(t, client.Get(nil, k1, &o1a))
+	if o1a.Value != o1.Value {
+		t.Fatal("Failed put/get", o1a, o1)
 	}
 
 	// A second object should not interfere with the first.
-	// c := Object{"other"} // TODO - reuse b instead to test independence.
-	b.Value = "other"
-	_, err = client.Put(nil, key2, &b)
+	o2 := Object{"o2"}
+	_, err = client.Put(nil, k2, &o2)
 	must(t, err)
-	client.DumpKeys()
 
-	b.Value = ""
-	must(t, client.Get(nil, key, &b))
-	if b.Value != a.Value {
-		t.Fatal("Apparent object collision", a, b)
+	// Check that Get still fetches the correct o1 value
+	var o1b Object
+	must(t, client.Get(nil, k1, &o1b))
+	if o1b.Value != o1.Value {
+		t.Fatal("Apparent object collision", o1b, o1)
 	}
 
-	// test DumpKeys
+	client.DumpKeys()
+	o2.Value = "local-o2"
+	// Check that changing original object doesn't change the stored value.
+	var o2a Object
+	must(t, client.Get(nil, k2, &o2a))
+	if o2a.Value != "o2" {
+		t.Error("Changing local modifies persisted value", o2a.Value, "!=", "o2")
+	}
+
+	// test DumpKeys()
 	keys := client.DumpKeys()
 	if len(keys) != 2 {
 		t.Fatal("Should be 2 keys")
 	}
-	if keys[0] != *key && keys[1] != *key {
-		t.Error("Missing key", key)
+	if keys[0] != *k1 && keys[1] != *k1 {
+		t.Error("Missing key", k1)
 	}
-	if keys[0] != *key2 && keys[1] != *key2 {
-		t.Error("Missing key", key2)
+	if keys[0] != *k2 && keys[1] != *k2 {
+		t.Error("Missing key", k2)
 	}
 
-	must(t, client.Delete(nil, key))
-	err = client.Get(nil, key, &a)
+	// Test Delete()
+	must(t, client.Delete(nil, k1))
+	err = client.Get(nil, k1, &o1b)
 	if err != datastore.ErrNoSuchEntity {
 		t.Fatal("delete failed")
-	}
-
-	var c Object
-	// key2 object should still exist
-	must(t, client.Get(nil, key2, &c))
-	if c.Value != "other" {
-		t.Error("Wrong value", c.Value)
 	}
 
 }

--- a/cloudtest/dsfake/dsfake_test.go
+++ b/cloudtest/dsfake/dsfake_test.go
@@ -60,7 +60,6 @@ func TestDSFake(t *testing.T) {
 		t.Fatal("Apparent object collision", o1b, o1)
 	}
 
-	client.DumpKeys()
 	o2.Value = "local-o2"
 	// Check that changing original object doesn't change the stored value.
 	var o2a Object
@@ -69,8 +68,7 @@ func TestDSFake(t *testing.T) {
 		t.Error("Changing local modifies persisted value", o2a.Value, "!=", "o2")
 	}
 
-	// test DumpKeys()
-	keys := client.DumpKeys()
+	keys := client.GetKeys()
 	if len(keys) != 2 {
 		t.Fatal("Should be 2 keys")
 	}


### PR DESCRIPTION
FYI, I put this in the existing cloudtest directory, but in a separate subdirectory and package.
We have a divergence, since bqfake is now in cloud/bqfake, instead of cloudtest.  Should discuss how best to organize this repo, to reflect test helpers vs enhancements.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/go/78)
<!-- Reviewable:end -->
