### PR TITLE
Add DateTime and Time flag types

### DIFF
--- a/flagx/time.go
+++ b/flagx/time.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/araddon/dateparse"
-	"src/github.com/m-lab/go/rtx"
+	"github.com/m-lab/go/rtx"
 )
 
 // ErrBadTimeFormat is returned when failing to parse a Time value.

--- a/flagx/time.go
+++ b/flagx/time.go
@@ -17,22 +17,21 @@ var timeFormat = "15:04:05"
 // DateTime is a flag type for accepting date parameters.
 type DateTime struct {
 	time.Time
-	Raw string // The original string parameter.
 }
 
-// Get retrieves the current date value contained in the flag as a string.
+// Get retrieves the current date value as a string.
 func (t DateTime) Get() string {
-	return t.Raw
+	return t.Time.String()
 }
 
 // Set parses and assigns the DateTime value. DateTime accepts all formats
 // supported by the "github.com/araddon/dateparse" package.
 func (t *DateTime) Set(s string) error {
-	(*t).Raw = s
 	_, err := dateparse.ParseStrict(s)
 	if err != nil {
 		return err
 	}
+	// Enforce UTC times.
 	f, err := dateparse.ParseIn(s, time.UTC)
 	// If ParseStrict succeeds, then ParseIn is always expected to succeed.
 	rtx.Must(err, "Failed to infer format from %q", s)
@@ -40,11 +39,7 @@ func (t *DateTime) Set(s string) error {
 	return nil
 }
 
-// String reports the Raw value used to derive the DateTime value. The raw value
-// is provided because not all formats supported by parsedate are supported by
-// time.Format (e.g. unix timestamps). The DateTime type relies on
-// dateparse.ParseStrict errors to enforce equivalence between the .Raw and
-// .Time values.
+// String reports the parsed time as a string using time.Time.String().
 func (t DateTime) String() string {
 	return t.Get()
 }

--- a/flagx/time.go
+++ b/flagx/time.go
@@ -1,0 +1,124 @@
+package flagx
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// ErrBadFormat is a static error returned when attempting to parse an unsupported flag format.
+var ErrBadFormat = fmt.Errorf("ErrBadFormat: unsupported time format")
+
+// Local prototype time formats.
+var timeFormat = "15:04:05"
+var dateFormat = "2006-01-02"
+var dateTimeFormat = "2006-01-02T15:04:05"
+
+// DateTime is a new flag type.
+type DateTime struct {
+	Date
+	Time
+}
+
+// Get retrieves the value contained in the flag.
+func (t DateTime) Get() string {
+	return t.Date.String() + "T" + t.Time.String()
+}
+
+// Set parses and assigns the DateTime value. As a convenience, DateTime accepts
+// abbreviated formats for date. For example: 2019-01-30 or 2019-01-30T01:01:34
+func (t *DateTime) Set(s string) error {
+	switch {
+	case len(s) == len(dateFormat):
+		return (*t).Date.Set(s)
+	case len(s) == len(dateTimeFormat):
+		f := strings.Split(s, "T")
+		if len(f) != 2 {
+			return ErrBadFormat
+		}
+		err := (*t).Date.Set(f[0])
+		if err != nil {
+			return err
+		}
+		return (*t).Time.Set(f[1])
+	default:
+		return ErrBadFormat
+	}
+}
+
+// String reports the set Time value.
+func (t DateTime) String() string {
+	return t.Get()
+}
+
+// Date is a new flag type.
+type Date struct {
+	Year  int
+	Month int
+	Day   int
+}
+
+// Get retrieves the value contained in the flag.
+func (t Date) Get() string {
+	return fmt.Sprintf("%04d-%02d-%02d", t.Year, t.Month, t.Day)
+}
+
+// Set parses and assigns the Date Year, Month, and Day values.
+func (t *Date) Set(s string) error {
+	var format string
+	switch {
+	case len(s) == len(dateFormat):
+		format = dateFormat
+	default:
+		return ErrBadFormat
+	}
+	tmp, err := time.Parse(format, s)
+	if err != nil {
+		return err
+	}
+	(*t).Year = tmp.Year()
+	(*t).Month = int(tmp.Month())
+	(*t).Day = tmp.Day()
+	return nil
+}
+
+// String reports the set Time value.
+func (t Date) String() string {
+	return t.Get()
+}
+
+// Time is a new flag type.
+type Time struct {
+	Hour   int
+	Minute int
+	Second int
+}
+
+// Get retrieves the value contained in the flag.
+func (t Time) Get() string {
+	return fmt.Sprintf("%02d:%02d:%02d", t.Hour, t.Minute, t.Second)
+}
+
+// Set parses and assigns the Date Year, Month, and Day values.
+func (t *Time) Set(s string) error {
+	var format string
+	switch {
+	case len(s) == len(timeFormat):
+		format = timeFormat
+	default:
+		return ErrBadFormat
+	}
+	tmp, err := time.Parse(format, s)
+	if err != nil {
+		return err
+	}
+	(*t).Hour = tmp.Hour()
+	(*t).Minute = tmp.Minute()
+	(*t).Second = tmp.Second()
+	return nil
+}
+
+// String reports the set Time value.
+func (t Time) String() string {
+	return t.Get()
+}

--- a/flagx/time_test.go
+++ b/flagx/time_test.go
@@ -1,55 +1,52 @@
 package flagx
 
 import (
+	"fmt"
 	"testing"
+	"time"
 )
 
 func TestDateTime_Set(t *testing.T) {
 	tests := []struct {
 		name       string
 		arg        string
-		wantDate   Date
-		wantTime   Time
+		wantTime   time.Time
 		wantFormat string
 		wantErr    bool
 	}{
 		{
 			name:       "success-date",
 			arg:        "2019-03-30",
-			wantDate:   Date{2019, 3, 30},
-			wantFormat: "2019-03-30T00:00:00",
+			wantTime:   time.Date(2019, 3, 30, 0, 0, 0, 0, time.UTC),
+			wantFormat: "2019-03-30",
+		},
+		{
+			name:       "success-date-ambiguous",
+			arg:        "2019-03-01",
+			wantTime:   time.Date(2019, 3, 1, 0, 0, 0, 0, time.UTC),
+			wantFormat: "2019-03-01",
 		},
 		{
 			name:       "success-datetime",
 			arg:        "2019-03-30T12:34:56",
-			wantDate:   Date{2019, 3, 30},
-			wantTime:   Time{12, 34, 56},
+			wantTime:   time.Date(2019, 3, 30, 12, 34, 56, 0, time.UTC),
 			wantFormat: "2019-03-30T12:34:56",
 		},
 		{
+			name:       "success-datetime-seconds",
+			arg:        "1553949296001",
+			wantTime:   time.Date(2019, 3, 30, 12, 34, 56, 1000000, time.UTC),
+			wantFormat: "1553949296001",
+		},
+		{
 			name:    "error-bad-date",
-			arg:     "2019/06/30",
+			arg:     "019/06/30",
 			wantErr: true,
 		},
 
 		{
-			name:    "error-bad-datetime-separator",
-			arg:     "2019-06-30x12:34:56",
-			wantErr: true,
-		},
-		{
-			name:    "error-bad-datetime-length",
-			arg:     "2019-06-30T12:30",
-			wantErr: true,
-		},
-		{
-			name:    "error-bad-time",
-			arg:     "2019-06-30T12/30/00",
-			wantErr: true,
-		},
-		{
-			name:    "error-bad-date-with-right-length",
-			arg:     "2019/06/30T12:30:00",
+			name:    "error-bad-datetime-ambiguous",
+			arg:     "01/01/19",
 			wantErr: true,
 		},
 	}
@@ -62,59 +59,15 @@ func TestDateTime_Set(t *testing.T) {
 			if tt.wantErr {
 				return
 			}
-			if f.Date != tt.wantDate {
-				t.Errorf("DateTime.Set() parsed time not equal; got = %#v, want %#v", f.Date, tt.wantDate)
-			}
 			if f.Time != tt.wantTime {
-				t.Errorf("DateTime.Set() raw time not equal; got = %#v, want %#v", f.Time, tt.wantTime)
+				t.Errorf("DateTime.Set() raw time not equal; got = %s, want %s", f.Time, tt.wantTime)
 			}
 			if f.String() != tt.wantFormat {
 				t.Errorf("DateTime.String() format not equal; got = %q, want %q", f.String(), tt.wantFormat)
 			}
-		})
-	}
-}
-
-func TestDate_Set(t *testing.T) {
-	tests := []struct {
-		name       string
-		arg        string
-		wantDate   Date
-		wantFormat string
-		wantErr    bool
-	}{
-		{
-			name:       "success-date",
-			arg:        "2019-03-30",
-			wantDate:   Date{2019, 3, 30},
-			wantFormat: "2019-03-30",
-		},
-		{
-			name:    "error-bad-date",
-			arg:     "2019/06/30",
-			wantErr: true,
-		},
-		{
-			name:    "error-bad-length",
-			arg:     "2019-06-3",
-			wantErr: true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			f := Date{}
-			if err := f.Set(tt.arg); (err != nil) != tt.wantErr {
-				t.Errorf("Date.Set() error = %v, wantErr %v", err, tt.wantErr)
-			}
-			if tt.wantErr {
-				return
-			}
-			if f != tt.wantDate {
-				t.Errorf("Date.Set() parsed time not equal; got = %#v, want %#v", f, tt.wantDate)
-			}
-			if f.String() != tt.wantFormat {
-				t.Errorf("Date.String() format not equal; got = %q, want %q", f.String(), tt.wantFormat)
-			}
+			f2 := &DateTime{}
+			f2.Set(f.String())
+			fmt.Println(f2.String())
 		})
 	}
 }
@@ -128,7 +81,7 @@ func TestTime_Set(t *testing.T) {
 		wantErr    bool
 	}{
 		{
-			name:       "success-date",
+			name:       "success-time",
 			arg:        "19:03:30",
 			wantTime:   Time{19, 3, 30},
 			wantFormat: "19:03:30",

--- a/flagx/time_test.go
+++ b/flagx/time_test.go
@@ -17,25 +17,25 @@ func TestDateTime_Set(t *testing.T) {
 			name:       "success-date",
 			arg:        "2019-03-30",
 			wantTime:   time.Date(2019, 3, 30, 0, 0, 0, 0, time.UTC),
-			wantFormat: "2019-03-30",
+			wantFormat: "2019-03-30 00:00:00 +0000 UTC",
 		},
 		{
 			name:       "success-date-ambiguous",
 			arg:        "2019-03-01",
 			wantTime:   time.Date(2019, 3, 1, 0, 0, 0, 0, time.UTC),
-			wantFormat: "2019-03-01",
+			wantFormat: "2019-03-01 00:00:00 +0000 UTC",
 		},
 		{
 			name:       "success-datetime",
 			arg:        "2019-03-30T12:34:56",
 			wantTime:   time.Date(2019, 3, 30, 12, 34, 56, 0, time.UTC),
-			wantFormat: "2019-03-30T12:34:56",
+			wantFormat: "2019-03-30 12:34:56 +0000 UTC",
 		},
 		{
 			name:       "success-datetime-milliseconds",
 			arg:        "1553949296001",
 			wantTime:   time.Date(2019, 3, 30, 12, 34, 56, 1000000, time.UTC),
-			wantFormat: "1553949296001",
+			wantFormat: "2019-03-30 12:34:56.001 +0000 UTC",
 		},
 		{
 			name:    "error-bad-date",
@@ -63,6 +63,15 @@ func TestDateTime_Set(t *testing.T) {
 			}
 			if f.String() != tt.wantFormat {
 				t.Errorf("DateTime.String() format not equal; got = %q, want %q", f.String(), tt.wantFormat)
+			}
+			// Verify that the formatted string can be parsed an equals the original.
+			f2 := &DateTime{}
+			err := f2.Set(f.String())
+			if err != nil {
+				t.Errorf("DateTime.Set() with formatted time failed; got = %q, want nil", err)
+			}
+			if !f2.Time.Equal(f.Time) {
+				t.Errorf("DateTime.Set() with formatted time got different time! got = %q, want %q", f2.Time, f.Time)
 			}
 		})
 	}

--- a/flagx/time_test.go
+++ b/flagx/time_test.go
@@ -32,7 +32,7 @@ func TestDateTime_Set(t *testing.T) {
 			wantFormat: "2019-03-30T12:34:56",
 		},
 		{
-			name:       "success-datetime-seconds",
+			name:       "success-datetime-milliseconds",
 			arg:        "1553949296001",
 			wantTime:   time.Date(2019, 3, 30, 12, 34, 56, 1000000, time.UTC),
 			wantFormat: "1553949296001",

--- a/flagx/time_test.go
+++ b/flagx/time_test.go
@@ -1,0 +1,164 @@
+package flagx
+
+import (
+	"testing"
+)
+
+func TestDateTime_Set(t *testing.T) {
+	tests := []struct {
+		name       string
+		arg        string
+		wantDate   Date
+		wantTime   Time
+		wantFormat string
+		wantErr    bool
+	}{
+		{
+			name:       "success-date",
+			arg:        "2019-03-30",
+			wantDate:   Date{2019, 3, 30},
+			wantFormat: "2019-03-30T00:00:00",
+		},
+		{
+			name:       "success-datetime",
+			arg:        "2019-03-30T12:34:56",
+			wantDate:   Date{2019, 3, 30},
+			wantTime:   Time{12, 34, 56},
+			wantFormat: "2019-03-30T12:34:56",
+		},
+		{
+			name:    "error-bad-date",
+			arg:     "2019/06/30",
+			wantErr: true,
+		},
+
+		{
+			name:    "error-bad-datetime-separator",
+			arg:     "2019-06-30x12:34:56",
+			wantErr: true,
+		},
+		{
+			name:    "error-bad-datetime-length",
+			arg:     "2019-06-30T12:30",
+			wantErr: true,
+		},
+		{
+			name:    "error-bad-time",
+			arg:     "2019-06-30T12/30/00",
+			wantErr: true,
+		},
+		{
+			name:    "error-bad-date-with-right-length",
+			arg:     "2019/06/30T12:30:00",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := &DateTime{}
+			if err := f.Set(tt.arg); (err != nil) != tt.wantErr {
+				t.Errorf("DateTime.Set() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if f.Date != tt.wantDate {
+				t.Errorf("DateTime.Set() parsed time not equal; got = %#v, want %#v", f.Date, tt.wantDate)
+			}
+			if f.Time != tt.wantTime {
+				t.Errorf("DateTime.Set() raw time not equal; got = %#v, want %#v", f.Time, tt.wantTime)
+			}
+			if f.String() != tt.wantFormat {
+				t.Errorf("DateTime.String() format not equal; got = %q, want %q", f.String(), tt.wantFormat)
+			}
+		})
+	}
+}
+
+func TestDate_Set(t *testing.T) {
+	tests := []struct {
+		name       string
+		arg        string
+		wantDate   Date
+		wantFormat string
+		wantErr    bool
+	}{
+		{
+			name:       "success-date",
+			arg:        "2019-03-30",
+			wantDate:   Date{2019, 3, 30},
+			wantFormat: "2019-03-30",
+		},
+		{
+			name:    "error-bad-date",
+			arg:     "2019/06/30",
+			wantErr: true,
+		},
+		{
+			name:    "error-bad-length",
+			arg:     "2019-06-3",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := Date{}
+			if err := f.Set(tt.arg); (err != nil) != tt.wantErr {
+				t.Errorf("Date.Set() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if f != tt.wantDate {
+				t.Errorf("Date.Set() parsed time not equal; got = %#v, want %#v", f, tt.wantDate)
+			}
+			if f.String() != tt.wantFormat {
+				t.Errorf("Date.String() format not equal; got = %q, want %q", f.String(), tt.wantFormat)
+			}
+		})
+	}
+}
+
+func TestTime_Set(t *testing.T) {
+	tests := []struct {
+		name       string
+		arg        string
+		wantTime   Time
+		wantFormat string
+		wantErr    bool
+	}{
+		{
+			name:       "success-date",
+			arg:        "19:03:30",
+			wantTime:   Time{19, 3, 30},
+			wantFormat: "19:03:30",
+		},
+		{
+			name:    "error-bad-time",
+			arg:     "19.06.30",
+			wantErr: true,
+		},
+		{
+			name:    "error-bad-length",
+			arg:     "19:06:3",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := Time{}
+			if err := f.Set(tt.arg); (err != nil) != tt.wantErr {
+				t.Errorf("Time.Set() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if f != tt.wantTime {
+				t.Errorf("Time.Set() parsed time not equal; got = %#v, want %#v", f, tt.wantTime)
+			}
+			if f.String() != tt.wantFormat {
+				t.Errorf("Time.String() format not equal; got = %q, want %q", f.String(), tt.wantFormat)
+			}
+		})
+	}
+}

--- a/flagx/time_test.go
+++ b/flagx/time_test.go
@@ -1,7 +1,6 @@
 package flagx
 
 import (
-	"fmt"
 	"testing"
 	"time"
 )
@@ -65,9 +64,6 @@ func TestDateTime_Set(t *testing.T) {
 			if f.String() != tt.wantFormat {
 				t.Errorf("DateTime.String() format not equal; got = %q, want %q", f.String(), tt.wantFormat)
 			}
-			f2 := &DateTime{}
-			f2.Set(f.String())
-			fmt.Println(f2.String())
 		})
 	}
 }


### PR DESCRIPTION
This change adds two new flagx types for supporting `flagx.DateTime` (various formats) and `flagx.Time` HH:MM:SS formats.

The DateTime flag uses the golang `time.Time` type, and parses using the `github.com/araddon/dateparse` package.

The Time flag use `time.Parse` to extract the individual Hour, Minute, and Second values.

The test coverage for each type would allow us to remove any type without impacting the coverage of the others.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/go/80)
<!-- Reviewable:end -->
