### PR TITLE
Only print warning if text is different.

### DIFF
--- a/bqx/schema.go
+++ b/bqx/schema.go
@@ -280,9 +280,9 @@ func UpdateSchemaDescription(schema bigquery.Schema, docs SchemaDoc) error {
 				// This is not an error, the field simply doesn't have extra description.
 				return nil
 			}
-			if field.Description != "" {
-				log.Printf("WARNING: Overwriting existing description for %q: %q",
-					field.Name, field.Description)
+			if field.Description != "" && field.Description != d["Description"] {
+				log.Printf("WARNING: Overwriting existing description for %q: %q vs %q",
+					field.Name, field.Description, d["Description"])
 			}
 			field.Description = d["Description"]
 			return nil


### PR DESCRIPTION
This change adds an additional condition to prevent printing warnings for cached fields returned by `bigquery.InferSchema` that already match.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/go/85)
<!-- Reviewable:end -->
