### PR TITLE
Add storagex.Bucket.Dirs method

### DIFF
--- a/storagex/walk.go
+++ b/storagex/walk.go
@@ -3,9 +3,11 @@ package storagex
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"log"
 	"path"
+	"regexp"
 	"strings"
 
 	"cloud.google.com/go/storage"
@@ -64,8 +66,44 @@ func (b *Bucket) Walk(ctx context.Context, pathPrefix string, visit func(o *Obje
 	return walk(ctx, b, pathPrefix, pathPrefix, visit)
 }
 
+// WalkIf visits each GCS path object under pathRegex and calls visit with each.
+func (b *Bucket) WalkIf(ctx context.Context, pathRegex string, visit func(o *Object) error) error {
+	return walkIf(ctx, b, pathRegex, "", visit)
+}
+
 var itNext = func(it *storage.ObjectIterator) (*storage.ObjectAttrs, error) {
 	return it.Next()
+}
+
+func walkIf(ctx context.Context, bucket *Bucket, pathRegex, rootPrefix string, visit func(o *Object) error) error {
+	it := bucket.Objects(ctx, &storage.Query{Prefix: rootPrefix, Delimiter: "/"})
+	for {
+		attr, err := itNext(it)
+		if err == iterator.Done {
+			return nil
+		}
+		if err != nil {
+			log.Println("failed to list bucket:", err)
+			return err
+		}
+		fmt.Println("prefix", attr.Prefix)
+		m, err := regexp.MatchString(pathRegex, attr.Prefix)
+		if m {
+			// We found an object.
+			fmt.Println("no name", attr.Name, attr.Prefix)
+			visit(&Object{ObjectHandle: bucket.Object(attr.Prefix), prefix: rootPrefix})
+			err = walkIf(ctx, bucket, pathRegex, attr.Prefix, visit)
+			if err != nil {
+				return err
+			}
+		} // else if !strings.HasSuffix(attr.Name, "/") {
+		// Pseudo-directory entries have no name.
+		// fmt.Println("no suffix", attr.Name, attr.Prefix)
+		// visit(&Object{ObjectHandle: bucket.Object(attr.Prefix), prefix: rootPrefix})
+		// } else {
+		// fmt.Println("else", attr.Name, attr.Prefix)
+		// }
+	}
 }
 
 // walk recursively iterates over every GCS Object in the given bucket whose
@@ -90,6 +128,24 @@ func walk(ctx context.Context, bucket *Bucket, prefix, rootPrefix string, visit 
 		} else if !strings.HasSuffix(attr.Name, "/") {
 			// We found an object.
 			visit(&Object{ObjectHandle: bucket.Object(attr.Name), prefix: rootPrefix})
+		}
+	}
+}
+
+func ListDirs(ctx context.Context, bucket *Bucket, rootPrefix string) ([]string, error) {
+	var ret []string
+	it := bucket.Objects(ctx, &storage.Query{Prefix: rootPrefix, Delimiter: "/"})
+	for {
+		attr, err := itNext(it)
+		if err == iterator.Done {
+			return ret, nil
+		}
+		if err != nil {
+			log.Println("failed to list bucket:", err)
+			return nil, err
+		}
+		if strings.HasSuffix(attr.Prefix, "/") {
+			ret = append(ret, attr.Prefix)
 		}
 	}
 }

--- a/storagex/walk.go
+++ b/storagex/walk.go
@@ -16,6 +16,7 @@ import (
 // generated during a Bucket.Walk.
 type Object struct {
 	*storage.ObjectHandle
+	*storage.ObjectAttrs
 	prefix string
 }
 
@@ -93,7 +94,11 @@ func walk(ctx context.Context, bucket *Bucket, prefix, rootPrefix string, visit 
 			}
 		} else if !strings.HasSuffix(attr.Name, "/") {
 			// We found an object.
-			visit(&Object{ObjectHandle: bucket.Object(attr.Name), prefix: rootPrefix})
+			visit(&Object{
+				ObjectHandle: bucket.Object(attr.Name),
+				ObjectAttrs:  attr,
+				prefix:       rootPrefix,
+			})
 		}
 	}
 }

--- a/storagex/walk_test.go
+++ b/storagex/walk_test.go
@@ -7,15 +7,56 @@ import (
 	"io"
 	"io/ioutil"
 	"log"
+	"reflect"
 	"testing"
 	"time"
 
 	"cloud.google.com/go/storage"
 	"github.com/m-lab/go/rtx"
+	"google.golang.org/api/iterator"
 )
 
 func init() {
 	log.SetOutput(ioutil.Discard)
+}
+
+type fakeIter interface {
+	itNext(it *storage.ObjectIterator) (*storage.ObjectAttrs, error)
+}
+
+type errIter struct {
+	i int
+}
+
+func (e *errIter) itNext(it *storage.ObjectIterator) (*storage.ObjectAttrs, error) {
+	if e.i > 0 {
+		return nil, fmt.Errorf("Fake error")
+	}
+	e.i++
+	return it.Next()
+}
+
+type iterDone struct {
+	i      int
+	prefix string
+}
+
+type anyIter struct{}
+
+func (a *anyIter) itNext(it *storage.ObjectIterator) (*storage.ObjectAttrs, error) {
+	return it.Next()
+}
+
+func (d *iterDone) itNext(it *storage.ObjectIterator) (*storage.ObjectAttrs, error) {
+	if d.i > 0 {
+		return nil, iterator.Done
+	}
+	d.i++
+	attr := &storage.ObjectAttrs{
+		Name:   "",
+		Prefix: d.prefix,
+	}
+	return attr, nil
 }
 
 func TestBucket_Walk(t *testing.T) {
@@ -27,18 +68,10 @@ func TestBucket_Walk(t *testing.T) {
 		return nil
 	}
 
-	i := 0
-	itNextErr := func(it *storage.ObjectIterator) (*storage.ObjectAttrs, error) {
-		if i > 0 {
-			return nil, fmt.Errorf("Fake error")
-		}
-		i = i + 1
-		return it.Next()
-	}
-
 	tests := []struct {
 		name    string
 		prefix  string
+		iter    fakeIter
 		wantErr bool
 	}{
 		{
@@ -48,6 +81,7 @@ func TestBucket_Walk(t *testing.T) {
 		{
 			name:    "okay-err",
 			prefix:  "t1",
+			iter:    &errIter{},
 			wantErr: true,
 		},
 	}
@@ -56,8 +90,8 @@ func TestBucket_Walk(t *testing.T) {
 		defer cancel()
 		bucket := NewBucket(client.Bucket("m-lab-go-storagex-mlab-testing"))
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.wantErr {
-				itNext = itNextErr
+			if tt.iter != nil {
+				bucket.itNext = tt.iter.itNext
 			}
 			if err := bucket.Walk(ctx, tt.prefix, visit); (err != nil) != tt.wantErr {
 				t.Errorf("walk() error = %v, wantErr %v", err, tt.wantErr)
@@ -72,7 +106,7 @@ func (f *errorWriter) Write(p []byte) (n int, err error) {
 	return 0, fmt.Errorf("Fake write error")
 }
 
-func TestObjectImpl_Copy(t *testing.T) {
+func TestObject_Copy(t *testing.T) {
 	ctx := context.Background()
 	client, err := storage.NewClient(ctx)
 	rtx.Must(err, "Failed to create client")
@@ -124,7 +158,7 @@ func TestObjectImpl_Copy(t *testing.T) {
 	}
 }
 
-func TestObjectImpl_LocalName(t *testing.T) {
+func TestObject_LocalName(t *testing.T) {
 	// An empty client is sufficient, since we make no network operations.
 	client := storage.Client{}
 
@@ -155,6 +189,50 @@ func TestObjectImpl_LocalName(t *testing.T) {
 			}
 			if got := o.LocalName(); got != tt.want {
 				t.Errorf("Object.LocalName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBucket_Dirs(t *testing.T) {
+	ctx := context.Background()
+	client, err := storage.NewClient(ctx)
+	rtx.Must(err, "Failed to create client")
+	tests := []struct {
+		name    string
+		b       *storage.BucketHandle
+		iter    fakeIter
+		want    []string
+		wantErr bool
+	}{
+		{
+			name: "success",
+			iter: &iterDone{prefix: "foo/"},
+			b:    client.Bucket("m-lab-go-storagex-mlab-testing"),
+			want: []string{"foo/"},
+		},
+		{
+			name:    "error-x",
+			b:       client.Bucket("m-lab-go-storagex-mlab-testing"),
+			iter:    &errIter{},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := &Bucket{
+				BucketHandle: tt.b,
+				itNext:       tt.iter.itNext,
+			}
+			ctx := context.Background()
+			got, err := b.Dirs(ctx, "")
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Bucket.Dirs() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Bucket.Dirs() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/storagex/walk_test.go
+++ b/storagex/walk_test.go
@@ -20,10 +20,12 @@ func init() {
 	log.SetOutput(ioutil.Discard)
 }
 
+// fakeIter is the common interface for the implemented iter types below.
 type fakeIter interface {
 	itNext(it *storage.ObjectIterator) (*storage.ObjectAttrs, error)
 }
 
+// errIter allows injecting iteration errors.
 type errIter struct {
 	i int
 }
@@ -36,15 +38,10 @@ func (e *errIter) itNext(it *storage.ObjectIterator) (*storage.ObjectAttrs, erro
 	return it.Next()
 }
 
+// iterDone allows injecting a single synthetic "directory" object.
 type iterDone struct {
 	i      int
 	prefix string
-}
-
-type anyIter struct{}
-
-func (a *anyIter) itNext(it *storage.ObjectIterator) (*storage.ObjectAttrs, error) {
-	return it.Next()
 }
 
 func (d *iterDone) itNext(it *storage.ObjectIterator) (*storage.ObjectAttrs, error) {
@@ -207,8 +204,8 @@ func TestBucket_Dirs(t *testing.T) {
 	}{
 		{
 			name: "success",
-			iter: &iterDone{prefix: "foo/"},
 			b:    client.Bucket("m-lab-go-storagex-mlab-testing"),
+			iter: &iterDone{prefix: "foo/"},
 			want: []string{"foo/"},
 		},
 		{


### PR DESCRIPTION
This change adds a new method to the storagex.Bucket type to list "directories" relative to a given prefix. Directories in GCS are synthetic, but match standard UNIX intuition except for the root prefix, which is "" not "/".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/go/86)
<!-- Reviewable:end -->
