### PR TITLE
Add support to StringArray for "," separated values and .Contains method

### DIFF
--- a/flagx/stringarray.go
+++ b/flagx/stringarray.go
@@ -1,11 +1,15 @@
 package flagx
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 // StringArray is a new flag type. It appends the flag parameter to an
-// `[]string` allowing the parameter to be specified multiple times. Unlike
-// other Flag types, the default argument should almost always be the empty
-// array, because there is no way to remove an element, only to add one.
+// `[]string` allowing the parameter to be specified multiple times or using ","
+// separated items. Unlike other Flag types, the default argument should almost
+// always be the empty array, because there is no way to remove an element, only
+// to add one.
 type StringArray []string
 
 // Get retrieves the value contained in the flag.
@@ -14,8 +18,11 @@ func (sa StringArray) Get() interface{} {
 }
 
 // Set accepts a string parameter and appends it to the associated StringArray.
+// Set attempts to split the given string on commas "," and appends each element
+// to the StringArray.
 func (sa *StringArray) Set(s string) error {
-	*sa = append(*sa, s)
+	f := strings.Split(s, ",")
+	*sa = append(*sa, f...)
 	return nil
 }
 

--- a/flagx/stringarray.go
+++ b/flagx/stringarray.go
@@ -30,3 +30,13 @@ func (sa *StringArray) Set(s string) error {
 func (sa StringArray) String() string {
 	return fmt.Sprintf("%#v", []string(sa))
 }
+
+// Contains returns true when the given value equals one of the StringArray values.
+func (sa StringArray) Contains(value string) bool {
+	for _, v := range sa {
+		if v == value {
+			return true
+		}
+	}
+	return false
+}

--- a/flagx/stringarray_test.go
+++ b/flagx/stringarray_test.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"testing"
 
+	"github.com/go-test/deep"
 	"github.com/m-lab/go/flagx"
 )
 
@@ -11,16 +12,25 @@ func TestStringArray(t *testing.T) {
 	tests := []struct {
 		name string
 		args []string
+		expt flagx.StringArray
 		repr string
 	}{
 		{
 			name: "okay",
 			args: []string{"a", "b"},
+			expt: flagx.StringArray{"a", "b"},
 			repr: `[]string{"a", "b"}`,
+		},
+		{
+			name: "okay-split-commas",
+			args: []string{"a", "b", "c,d"},
+			expt: flagx.StringArray{"a", "b", "c", "d"},
+			repr: `[]string{"a", "b", "c", "d"}`,
 		},
 		{
 			name: "empty",
 			args: []string{},
+			expt: flagx.StringArray{},
 			repr: `[]string{}`,
 		},
 	}
@@ -33,11 +43,8 @@ func TestStringArray(t *testing.T) {
 				}
 			}
 			v := (sa.Get().(flagx.StringArray))
-			for i := range v {
-				if v[i] != tt.args[i] {
-					t.Errorf("StringArray.Get() want[%d] = %q, got[%d] %q",
-						i, tt.args[i], i, v[i])
-				}
+			if diff := deep.Equal(v, tt.expt); diff != nil {
+				t.Errorf("StringArray.Get() unexpected differences %v", diff)
 			}
 			if tt.repr != sa.String() {
 				t.Errorf("StringArray.String() want = %q, got %q", tt.repr, sa.String())

--- a/flagx/stringarray_test.go
+++ b/flagx/stringarray_test.go
@@ -10,28 +10,34 @@ import (
 
 func TestStringArray(t *testing.T) {
 	tests := []struct {
-		name string
-		args []string
-		expt flagx.StringArray
-		repr string
+		name     string
+		args     []string
+		expt     flagx.StringArray
+		repr     string
+		contains string
+		wantErr  bool
 	}{
 		{
-			name: "okay",
-			args: []string{"a", "b"},
-			expt: flagx.StringArray{"a", "b"},
-			repr: `[]string{"a", "b"}`,
+			name:     "okay",
+			args:     []string{"a", "b"},
+			expt:     flagx.StringArray{"a", "b"},
+			repr:     `[]string{"a", "b"}`,
+			contains: "b",
 		},
 		{
-			name: "okay-split-commas",
-			args: []string{"a", "b", "c,d"},
-			expt: flagx.StringArray{"a", "b", "c", "d"},
-			repr: `[]string{"a", "b", "c", "d"}`,
+			name:     "okay-split-commas",
+			args:     []string{"a", "b", "c,d"},
+			expt:     flagx.StringArray{"a", "b", "c", "d"},
+			repr:     `[]string{"a", "b", "c", "d"}`,
+			contains: "d",
 		},
 		{
-			name: "empty",
-			args: []string{},
-			expt: flagx.StringArray{},
-			repr: `[]string{}`,
+			name:     "empty",
+			args:     []string{},
+			expt:     flagx.StringArray{},
+			repr:     `[]string{}`,
+			contains: "a",
+			wantErr:  true,
 		},
 	}
 	for _, tt := range tests {
@@ -48,6 +54,9 @@ func TestStringArray(t *testing.T) {
 			}
 			if tt.repr != sa.String() {
 				t.Errorf("StringArray.String() want = %q, got %q", tt.repr, sa.String())
+			}
+			if sa.Contains(tt.contains) == tt.wantErr {
+				t.Errorf("StringArray.Contains() want = %q, got %t", tt.repr, sa.Contains(tt.contains))
 			}
 		})
 	}


### PR DESCRIPTION
This change adds support to StringArray to split values on "," and append each element to the StringArray individually. As well, this change adds a new method `StringArray.Contains` to easily check whether the string array contains a specific value.

This change should be backward compatible, with the exception of values with literal ",".

This is in support of removing the need for flaga.Strings in https://github.com/m-lab/gcp-config/pull/9

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/go/90)
<!-- Reviewable:end -->
