### PR TITLE
Don't anonymize local IP addresses

### DIFF
--- a/anonymize/ip.go
+++ b/anonymize/ip.go
@@ -26,9 +26,32 @@ var (
 	// anonymization.
 	IPAnonymizationFlag = None
 
-	// IgnoredIPs is a set of flags that should be ignored and not anonymized.
-	// By default it is the set of local IP addresses. This set should be small,
-	// so it is represented as an array.
+	// IgnoredIPs is a set of IPs that should be ignored and not anonymized. By
+	// default it is the set of local IP addresses. This set should be small, so
+	// it is represented as an array because net.IP objects can't be used as map
+	// keys.
+	//
+	// If runtime profiling indicates this causes too much of a slowdown in
+	// practice, then the other design that is "near at hand" with Go primitives
+	// is to use map[string]struct{} where the string is the IP converted to a
+	// string. If that design also causes too much of a slowdown in practice,
+	// then we will have to fall back on our algorithms knowledge and build a
+	// clever data structure. The 3 main options are:
+	//  1. a bloom filter in front of a set object,
+	//  2. a 256-ary tree using each successive byte of the IP for each
+	//     successive level, or
+	//  3. a map[int32]struct{} for v4 addresses and a
+	//     map[int64](map[int64]struct{}) for v6 addresses.
+	// Likely the last option will be the fastest; ceteris paribus, native ints
+	// and language builtins tend to have the best performance.
+	//
+	// Big-O analysis doesn't buy us much here. There are a small number of
+	// local IPs and each one is of length 4 or 16. This means that taking the
+	// limit as N goes to infinity doesn't tell us much, because all of the
+	// quantities we might call "N" are 16 or less in all realistic scenarios,
+	// and 16 is a poor approximation of infinity. Therefore, any claims about
+	// relative speed of implementation need to be backed up by experimental
+	// evidence.
 	IgnoredIPs = []net.IP{}
 
 	// An injected log.Fatal to aid in testing.

--- a/anonymize/ip_test.go
+++ b/anonymize/ip_test.go
@@ -49,11 +49,13 @@ func TestNetblockAnon(t *testing.T) {
 	anon.IP(nil)                  // No crash = success
 	anon.IP(net.IP([]byte{1, 2})) // No crash = success
 
+	anonymize.IgnoredIPs = []net.IP{net.ParseIP("127.0.0.1")}
+
 	tests := []struct {
 		ip   string
 		want string
 	}{
-		{"127.0.0.1", "127.0.0.0"},
+		{"127.0.0.1", "127.0.0.1"}, // Localhost should be ignored.
 		{"10.1.2.3", "10.1.2.0"},
 		{"255.255.255.255", "255.255.255.0"},
 		{"0:1:2:3:4:5:6:7", "0:1:2:3::"},

--- a/anonymize/ip_test.go
+++ b/anonymize/ip_test.go
@@ -49,13 +49,14 @@ func TestNetblockAnon(t *testing.T) {
 	anon.IP(nil)                  // No crash = success
 	anon.IP(net.IP([]byte{1, 2})) // No crash = success
 
-	anonymize.IgnoredIPs = []net.IP{net.ParseIP("127.0.0.1")}
+	anonymize.IgnoredIPs = []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("1::2")}
 
 	tests := []struct {
 		ip   string
 		want string
 	}{
-		{"127.0.0.1", "127.0.0.1"}, // Localhost should be ignored.
+		{"127.0.0.1", "127.0.0.1"}, // IgnoredIPs should be ignored.
+		{"1:0::2", "1::2"},         // IgnoredIPs should be ignored.
 		{"10.1.2.3", "10.1.2.0"},
 		{"255.255.255.255", "255.255.255.0"},
 		{"0:1:2:3:4:5:6:7", "0:1:2:3::"},


### PR DESCRIPTION
IP anonymization now skips IP addresses obtained from the local machine.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/go/91)
<!-- Reviewable:end -->
