### PR TITLE
fix googleapis imports

### DIFF
--- a/bqext/dataset_test.go
+++ b/bqext/dataset_test.go
@@ -100,7 +100,6 @@ func TestGetTableStatsMock(t *testing.T) {
 	json.Unmarshal([]byte(wantTableMetadata), &want)
 
 	stats.ETag = "" // Ignore this field for comparison.
-	stats.Location = ""
 	if diff := deep.Equal(*stats, want); diff != nil {
 		t.Error(diff)
 	}

--- a/cloud/bqfake/bqfake.go
+++ b/cloud/bqfake/bqfake.go
@@ -14,7 +14,7 @@ import (
 	"log"
 
 	"cloud.google.com/go/bigquery"
-	"github.com/GoogleCloudPlatform/google-cloud-go-testing/bigquery/bqiface"
+	"github.com/googleapis/google-cloud-go-testing/bigquery/bqiface"
 	"google.golang.org/api/iterator"
 )
 

--- a/cloud/bqfake/bqfake_test.go
+++ b/cloud/bqfake/bqfake_test.go
@@ -12,7 +12,7 @@ import (
 	"google.golang.org/api/option"
 
 	"cloud.google.com/go/bigquery"
-	"github.com/GoogleCloudPlatform/google-cloud-go-testing/bigquery/bqiface"
+	"github.com/googleapis/google-cloud-go-testing/bigquery/bqiface"
 	"github.com/m-lab/go/cloud/bqfake"
 	"google.golang.org/api/iterator"
 )

--- a/cloud/bqfake/client.go
+++ b/cloud/bqfake/client.go
@@ -10,7 +10,7 @@ import (
 	"sync/atomic"
 
 	"cloud.google.com/go/bigquery"
-	"github.com/GoogleCloudPlatform/google-cloud-go-testing/bigquery/bqiface"
+	"github.com/googleapis/google-cloud-go-testing/bigquery/bqiface"
 	"google.golang.org/api/option"
 )
 

--- a/cloudtest/dsfake/dsfake.go
+++ b/cloudtest/dsfake/dsfake.go
@@ -13,7 +13,7 @@ import (
 	"sync"
 
 	"cloud.google.com/go/datastore"
-	"github.com/GoogleCloudPlatform/google-cloud-go-testing/datastore/dsiface"
+	"github.com/googleapis/google-cloud-go-testing/datastore/dsiface"
 )
 
 // NOTE: This is over-restrictive, but fine for current purposes.

--- a/cloudtest/gcs.go
+++ b/cloudtest/gcs.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 
 	"cloud.google.com/go/storage"
-	"github.com/GoogleCloudPlatform/google-cloud-go-testing/storage/stiface"
+	"github.com/googleapis/google-cloud-go-testing/storage/stiface"
 	"google.golang.org/api/iterator"
 )
 

--- a/cloudtest/gcs_test.go
+++ b/cloudtest/gcs_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/storage"
-	"github.com/GoogleCloudPlatform/google-cloud-go-testing/storage/stiface"
+	"github.com/googleapis/google-cloud-go-testing/storage/stiface"
 	"github.com/m-lab/go/cloudtest"
 	"google.golang.org/api/iterator"
 )

--- a/dataset/dataset.go
+++ b/dataset/dataset.go
@@ -25,7 +25,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/bigquery"
-	"github.com/GoogleCloudPlatform/google-cloud-go-testing/bigquery/bqiface"
+	"github.com/googleapis/google-cloud-go-testing/bigquery/bqiface"
 	"golang.org/x/net/context"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"

--- a/dataset/dataset_test.go
+++ b/dataset/dataset_test.go
@@ -101,7 +101,6 @@ func TestGetTableStatsMock(t *testing.T) {
 	json.Unmarshal([]byte(wantTableMetadata), &want)
 
 	stats.ETag = "" // Ignore this field for comparison.
-	stats.Location = ""
 	if diff := deep.Equal(*stats, want); diff != nil {
 		t.Error(diff)
 	}


### PR DESCRIPTION
GoogleCloudPlatform is apparently obsolete, and we should be using googleapis/...
This fixes all those imports.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/go/92)
<!-- Reviewable:end -->
