### PR TITLE
Add flagx.DurationArray with tests

### DIFF
--- a/flagx/durationarray.go
+++ b/flagx/durationarray.go
@@ -1,0 +1,38 @@
+package flagx
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// DurationArray collects time.Durations so a duration flag can be specified
+// multiple times or using "," separated items. The default argument should
+// almost always be the empty array, because there is no way to remove an
+// element, only to add one.
+type DurationArray []time.Duration
+
+// Get retrieves the value contained in the flag.
+func (da DurationArray) Get() interface{} {
+	return da
+}
+
+// Set appends the given time.Duration to the DurationArray. Set accepts
+// multiple durations separated by commas "," and appends each element to the
+// DurationArray.
+func (da *DurationArray) Set(s string) error {
+	f := strings.Split(s, ",")
+	for _, d := range f {
+		dur, err := time.ParseDuration(d)
+		if err != nil {
+			return err
+		}
+		*da = append(*da, dur)
+	}
+	return nil
+}
+
+// String reports the DurationArray as a Go value.
+func (da DurationArray) String() string {
+	return fmt.Sprintf("%+v", []time.Duration(da))
+}

--- a/flagx/durationarray_test.go
+++ b/flagx/durationarray_test.go
@@ -1,0 +1,71 @@
+package flagx_test
+
+import (
+	"flag"
+	"testing"
+	"time"
+
+	"github.com/go-test/deep"
+	"github.com/m-lab/go/flagx"
+)
+
+func TestDurationArray(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		expt    flagx.DurationArray
+		repr    string
+		wantErr bool
+	}{
+		{
+			name: "okay",
+			args: []string{"1s", "1m", "1h"},
+			expt: flagx.DurationArray{time.Second, time.Minute, time.Hour},
+			repr: `[1s 1m0s 1h0m0s]`,
+		},
+		{
+			name: "okay-split-commas",
+			args: []string{"1s,1m,1h"},
+			expt: flagx.DurationArray{time.Second, time.Minute, time.Hour},
+			repr: `[1s 1m0s 1h0m0s]`,
+		},
+		{
+			name:    "empty",
+			args:    []string{},
+			expt:    flagx.DurationArray{},
+			repr:    `[]`,
+			wantErr: true,
+		},
+		{
+			name:    "error-bad-format",
+			args:    []string{"this-is-not-a-duration"},
+			expt:    flagx.DurationArray{},
+			repr:    `[]`,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			da := &flagx.DurationArray{}
+			for i := range tt.args {
+				err := da.Set(tt.args[i])
+				if (err != nil) != tt.wantErr {
+					t.Errorf("DurationArray.Set() error = %v, want nil", err)
+				}
+			}
+			v := (da.Get().(flagx.DurationArray))
+			if diff := deep.Equal(v, tt.expt); diff != nil {
+				t.Errorf("DurationArray.Get() unexpected differences %v", diff)
+			}
+			if tt.repr != da.String() {
+				t.Errorf("DurationArray.String() want = %q, got %q", tt.repr, da.String())
+			}
+		})
+	}
+}
+
+// Successful compilation of this function means that DurationArray implements the
+// flag.Value interface. The function need not be called.
+func assertFlagDurationArray(b flagx.DurationArray) {
+	func(in flag.Value) {}(&b)
+}


### PR DESCRIPTION
This change adds a new flagx type for arrays of time.Durations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/go/95)
<!-- Reviewable:end -->
