### PR TITLE
Add flagx.URL type

### DIFF
--- a/flagx/url.go
+++ b/flagx/url.go
@@ -6,13 +6,14 @@ import (
 	"github.com/m-lab/go/rtx"
 )
 
-// URL is a flag type that parses the given URL string, handling errors during
-// flag parsing. See MustNewURL() to set a default value.
+// URL is a flag type for parses URL strings and handling errors during flag
+// parsing. Use MustNewURL() to specify a default value.
 type URL struct {
 	*url.URL
 }
 
-// MustNewURL creates a new URL flag initalized with the given value. For example:
+// MustNewURL creates a new flagx.URL initalized with the given value. Failure
+// to parse is fatal. For example:
 //   f := flagx.MustNewURL("http://example.com")
 func MustNewURL(s string) URL {
 	u := URL{}
@@ -20,12 +21,12 @@ func MustNewURL(s string) URL {
 	return u
 }
 
-// Get retrieves the inner URL.
-func (u URL) Get() *url.URL {
+// Get returns the inner *url.URL type.
+func (u *URL) Get() *url.URL {
 	return u.URL
 }
 
-// Set accepts a URL, parses it, and stores the result.
+// Set parses a URL string and stores the result.
 func (u *URL) Set(s string) error {
 	var err error
 	(*u).URL, err = url.Parse(s)
@@ -36,6 +37,6 @@ func (u *URL) Set(s string) error {
 }
 
 // String formats the underlying URL as a string.
-func (u URL) String() string {
+func (u *URL) String() string {
 	return u.URL.String()
 }

--- a/flagx/url.go
+++ b/flagx/url.go
@@ -1,0 +1,41 @@
+package flagx
+
+import (
+	"net/url"
+
+	"github.com/m-lab/go/rtx"
+)
+
+// URL is a flag type that parses the given URL string, handling errors during
+// flag parsing. See MustNewURL() to set a default value.
+type URL struct {
+	*url.URL
+}
+
+// MustNewURL creates a new URL flag initalized with the given value. For example:
+//   f := flagx.MustNewURL("http://example.com")
+func MustNewURL(s string) URL {
+	u := URL{}
+	rtx.Must(u.Set(s), "Failed to parse and set given URL %q", s)
+	return u
+}
+
+// Get retrieves the inner URL.
+func (u URL) Get() *url.URL {
+	return u.URL
+}
+
+// Set accepts a URL, parses it, and stores the result.
+func (u *URL) Set(s string) error {
+	var err error
+	(*u).URL, err = url.Parse(s)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// String formats the underlying URL as a string.
+func (u URL) String() string {
+	return u.URL.String()
+}

--- a/flagx/url.go
+++ b/flagx/url.go
@@ -6,13 +6,13 @@ import (
 	"github.com/m-lab/go/rtx"
 )
 
-// URL is a flag type for parses URL strings and handling errors during flag
+// URL is a flag type for parsing URL strings and handling errors during flag
 // parsing. Use MustNewURL() to specify a default value.
 type URL struct {
 	*url.URL
 }
 
-// MustNewURL creates a new flagx.URL initalized with the given value. Failure
+// MustNewURL creates a new flagx.URL initialized with the given value. Failure
 // to parse is fatal. For example:
 //   f := flagx.MustNewURL("http://example.com")
 func MustNewURL(s string) URL {

--- a/flagx/url_test.go
+++ b/flagx/url_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/m-lab/go/flagx"
 )
 
-func TestURL_Set(t *testing.T) {
+func TestURL(t *testing.T) {
 	tests := []struct {
 		name    string
 		s       string

--- a/flagx/url_test.go
+++ b/flagx/url_test.go
@@ -1,0 +1,64 @@
+package flagx_test
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/go-test/deep"
+	"github.com/m-lab/go/flagx"
+)
+
+func TestURL_Set(t *testing.T) {
+	tests := []struct {
+		name    string
+		s       string
+		want    *url.URL
+		wantErr bool
+	}{
+		{
+			name: "success-gs",
+			s:    "gs://bucket/path/object.tar.gz",
+			want: &url.URL{
+				Scheme: "gs",
+				Host:   "bucket",
+				Path:   "/path/object.tar.gz",
+			},
+		},
+		{
+			name: "success-https",
+			s:    "https://bucket:1234/path/object.tar.gz?this=that",
+			want: &url.URL{
+				Scheme:   "https",
+				Host:     "bucket:1234",
+				Path:     "/path/object.tar.gz",
+				RawQuery: "this=that",
+			},
+		},
+		{
+			name:    "error-bad-url-format",
+			s:       "://this-is-not-a-url",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			u := flagx.URL{}
+			if err := u.Set(tt.s); (err != nil) != tt.wantErr {
+				t.Errorf("URL.Set() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if u.String() != tt.s {
+				t.Errorf("URL.String() got = %q, want %q", u.String(), tt.s)
+			}
+			if diff := deep.Equal(u.Get(), tt.want); diff != nil {
+				t.Errorf("URL.Set()\ngot %#v\nwant %#v\ndifferences: %v", u.URL, tt.want, diff)
+			}
+			s := flagx.MustNewURL(tt.s)
+			if diff := deep.Equal(u, s); diff != nil {
+				t.Errorf("URL.Set and MustNewURL returned different values: %#v", diff)
+			}
+		})
+	}
+}

--- a/flagx/url_test.go
+++ b/flagx/url_test.go
@@ -42,19 +42,24 @@ func TestURL(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			// Attempt to set the URL.
 			u := flagx.URL{}
 			if err := u.Set(tt.s); (err != nil) != tt.wantErr {
 				t.Errorf("URL.Set() error = %v, wantErr %v", err, tt.wantErr)
 			}
+			// Skip remaining checks if we expect an error.
 			if tt.wantErr {
 				return
 			}
+			// Does the original URL match the reformatted URL?
 			if u.String() != tt.s {
 				t.Errorf("URL.String() got = %q, want %q", u.String(), tt.s)
 			}
+			// Does the parsed URL match the expected URL?
 			if diff := deep.Equal(u.Get(), tt.want); diff != nil {
 				t.Errorf("URL.Set()\ngot %#v\nwant %#v\ndifferences: %v", u.URL, tt.want, diff)
 			}
+			// Try to initialize a flag using the original test value.
 			s := flagx.MustNewURL(tt.s)
 			if diff := deep.Equal(u, s); diff != nil {
 				t.Errorf("URL.Set and MustNewURL returned different values: %#v", diff)


### PR DESCRIPTION
This change adds a new command line flagx type for parsing URLs.

The use-case for this came from recent work on uuid-annotator where we will need at least three URLs for maxmind, IPv4 & IPv6 routeview databases. If more parsing can happen during flag processing, then the setup logic in main can be simpler.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/go/101)
<!-- Reviewable:end -->
