### PR TITLE
Return empty String if URL.URL is nil

### DIFF
--- a/flagx/url.go
+++ b/flagx/url.go
@@ -38,5 +38,8 @@ func (u *URL) Set(s string) error {
 
 // String formats the underlying URL as a string.
 func (u *URL) String() string {
+	if u.URL == nil {
+		return ""
+	}
 	return u.URL.String()
 }

--- a/flagx/url_test.go
+++ b/flagx/url_test.go
@@ -39,11 +39,19 @@ func TestURL(t *testing.T) {
 			s:       "://this-is-not-a-url",
 			wantErr: true,
 		},
+		{
+			name: "error-empty-url",
+			s:    "",
+			want: &url.URL{},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Attempt to set the URL.
 			u := flagx.URL{}
+			if u.String() != "" {
+				t.Errorf("URL.String() empty URL flag returned a value %q", u.String())
+			}
 			if err := u.Set(tt.s); (err != nil) != tt.wantErr {
 				t.Errorf("URL.Set() error = %v, wantErr %v", err, tt.wantErr)
 			}

--- a/flagx/url_test.go
+++ b/flagx/url_test.go
@@ -1,6 +1,7 @@
 package flagx_test
 
 import (
+	"flag"
 	"net/url"
 	"testing"
 
@@ -74,4 +75,9 @@ func TestURL(t *testing.T) {
 			}
 		})
 	}
+}
+
+// Verify that flagx.URL implements the flag.Value interface.
+func assertFlagValueURL(b flagx.URL) {
+	func(in flag.Value) {}(&b)
 }


### PR DESCRIPTION
This change handles String() when the URL flag value is nil. Evidently String() is called during flag parsing, which requires handling the nil case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/go/102)
<!-- Reviewable:end -->
