### PR TITLE
Make Client.version a public field and let the user define it

### DIFF
--- a/siteinfo/client.go
+++ b/siteinfo/client.go
@@ -20,8 +20,8 @@ type HTTPProvider interface {
 // Client is a Siteinfo client.
 type Client struct {
 	ProjectID  string
+	Version    string
 	httpClient HTTPProvider
-	version    string
 }
 
 // New returns a new Siteinfo client wrapping the provided *http.Client.
@@ -29,7 +29,7 @@ func New(projectID, version string, httpClient HTTPProvider) *Client {
 	return &Client{
 		ProjectID:  projectID,
 		httpClient: httpClient,
-		version:    version,
+		Version:    version,
 	}
 }
 
@@ -59,5 +59,5 @@ func (s Client) Switches() (map[string]Switch, error) {
 }
 
 func (s Client) makeBaseURL() string {
-	return fmt.Sprintf(baseURLFormat, s.ProjectID, s.version)
+	return fmt.Sprintf(baseURLFormat, s.ProjectID, s.Version)
 }

--- a/siteinfo/client.go
+++ b/siteinfo/client.go
@@ -25,10 +25,11 @@ type Client struct {
 }
 
 // New returns a new Siteinfo client wrapping the provided *http.Client.
-func New(projectID string, httpClient HTTPProvider) *Client {
+func New(projectID, version string, httpClient HTTPProvider) *Client {
 	return &Client{
 		ProjectID:  projectID,
 		httpClient: httpClient,
+		version:    version,
 	}
 }
 

--- a/siteinfo/client_test.go
+++ b/siteinfo/client_test.go
@@ -74,7 +74,7 @@ func (mockReadCloser) Close() error {
 //
 
 func TestNew(t *testing.T) {
-	client := New("project", http.DefaultClient)
+	client := New("project", "v1", http.DefaultClient)
 	if client == nil {
 		t.Errorf("New() returned nil.")
 	}
@@ -84,7 +84,7 @@ func TestClient_Switches(t *testing.T) {
 	prov := &fileReaderProvider{
 		path: "testdata/switches.json",
 	}
-	client := New("test", prov)
+	client := New("test", "v1", prov)
 
 	// This should return the content of the test file.
 	res, err := client.Switches()


### PR DESCRIPTION
Due to an oversight, there was no way to set the `version` field. This PR fixes that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/go/109)
<!-- Reviewable:end -->
