### PR TITLE
file: urls are a little more intricate than first imagined. This should cover all the cases.

### DIFF
--- a/content/provider.go
+++ b/content/provider.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -75,7 +76,7 @@ type fileProvider struct {
 func (f *fileProvider) Get(ctx context.Context) ([]byte, error) {
 	s, err := os.Stat(f.filename)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("Could not os.Stat(%q): %w", f.filename, err)
 	}
 	newtime := s.ModTime()
 	if newtime == f.mtime {
@@ -136,8 +137,13 @@ func FromURL(ctx context.Context, u *url.URL) (Provider, error) {
 			filename: filename,
 		}, err
 	case "file":
+		if u.Path == "" {
+			return &fileProvider{
+				filename: u.Opaque,
+			}, nil
+		}
 		return &fileProvider{
-			filename: u.Opaque,
+			filename: u.Path,
 		}, nil
 
 	case "https":

--- a/content/provider_test.go
+++ b/content/provider_test.go
@@ -38,6 +38,10 @@ func TestFileFromURLThenGet(t *testing.T) {
 			url:  "file://" + tf.Name(),
 		},
 		{
+			name: "Good file (absolute pathname, just a single slash)",
+			url:  "file:" + tf.Name(),
+		},
+		{
 			name:       "Nonexistent file",
 			url:        "file:///this/file/does/not/exist",
 			wantGetErr: true,

--- a/content/provider_test.go
+++ b/content/provider_test.go
@@ -39,7 +39,7 @@ func TestFileFromURLThenGet(t *testing.T) {
 		},
 		{
 			name:       "Nonexistent file",
-			url:        "file://this/file/does/not/exist",
+			url:        "file:///this/file/does/not/exist",
 			wantGetErr: true,
 		},
 		{

--- a/content/provider_test.go
+++ b/content/provider_test.go
@@ -5,9 +5,12 @@ import (
 	"context"
 	"errors"
 	"io"
+	"io/ioutil"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"reflect"
 	"testing"
 	"time"
@@ -18,14 +21,21 @@ import (
 )
 
 func TestFileFromURLThenGet(t *testing.T) {
+	tf, err := ioutil.TempFile("/tmp", "")
+	rtx.Must(err, "Could not create tempfile")
+	defer os.Remove(tf.Name())
 	tests := []struct {
 		name       string
 		url        string
 		wantGetErr bool
 	}{
 		{
-			name: "Good file",
+			name: "Good file (relative pathname)",
 			url:  "file:provider.go",
+		},
+		{
+			name: "Good file (absolute pathname)",
+			url:  "file://" + tf.Name(),
 		},
 		{
 			name:       "Nonexistent file",
@@ -40,6 +50,7 @@ func TestFileFromURLThenGet(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			log.Println(tt.url)
 			u, err := url.Parse(tt.url)
 			rtx.Must(err, "Could not parse URL")
 			provider, err := FromURL(context.Background(), u)


### PR DESCRIPTION
`file:filename` works (like it always did)
`file:/dir/filename` works (don't know if it previously did)
`file://dir/filename` is not a valid url, and as such will not be processed correctly even if the URL parser doesn't error out.
`file:///dir/filename` works now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/go/112)
<!-- Reviewable:end -->
