### PR TITLE
Add flagx.ArgsFromEnvWithLog

### DIFF
--- a/flagx/argsfromenv.go
+++ b/flagx/argsfromenv.go
@@ -53,6 +53,13 @@ func AssignedFlags(flagSet *flag.FlagSet) map[string]struct{} {
 // "-a" and "-A"), then the behavior of this function is unspecified and should
 // not be relied upon. Also, your flags should have more descriptive names.
 func ArgsFromEnv(flagSet *flag.FlagSet) error {
+	return ArgsFromEnvWithLog(flagSet, true)
+}
+
+// ArgsFromEnvWithLog operates as ArgsFromEnv with an additional option to
+// disable logging of all flag values. This is helpful for command line
+// applications that wish to disable extra argument logging.
+func ArgsFromEnvWithLog(flagSet *flag.FlagSet, logArgs bool) error {
 	// Allow environment variables to be used for unspecified commandline flags.
 	// Track what flags were explicitly set so that we won't override those flags.
 	specifiedFlags := AssignedFlags(flagSet)
@@ -71,7 +78,9 @@ func ArgsFromEnv(flagSet *flag.FlagSet) error {
 				}
 			}
 		}
-		log.Printf("Argument %s=%v\n", f.Name, f.Value)
+		if logArgs {
+			log.Printf("Argument %s=%v\n", f.Name, f.Value)
+		}
 	})
 	return err
 }


### PR DESCRIPTION
Fixes https://github.com/m-lab/go/issues/84

This change allows CLI callers to disable argument logging. This change preserves backward compatibility with all users of `flagx.ArgsFromEnv`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/go/113)
<!-- Reviewable:end -->
