### PR TITLE
Add flagx.FileBytesArray for lists of files

### DIFF
--- a/flagx/filebytesarray.go
+++ b/flagx/filebytesarray.go
@@ -1,0 +1,47 @@
+package flagx
+
+import (
+	"io/ioutil"
+	"strings"
+)
+
+// FileBytesArray is a new flag type that combines the semantics of StringArray
+// for multiple filenames and FileBytes for reading the content of each file.
+// Every filename is read as a `[]byte` and the contents appended to an
+// FileBytesArray of type `[][]byte`.
+//
+// Like StringArray, the flag parameter may be specified multiple times or using
+// "," separated items. Unlike other Flag types, the default argument should
+// almost always be the empty array, because there is no way to remove an
+// element, only to add one.
+type FileBytesArray struct {
+	// Bytes read from file names.
+	bytes [][]byte
+	// Names of files passed to Set. Preserved for meaningful String() output.
+	names []string
+}
+
+// Get retrieves the bytes read from the file (or the default bytes).
+func (fb *FileBytesArray) Get() [][]byte {
+	return fb.bytes
+}
+
+// Set accepts a filename (or filenames separated by comma) and reads the bytes
+// associated with the file and appends the bytes the FileBytesArray.
+func (fb *FileBytesArray) Set(s string) error {
+	f := strings.Split(s, ",")
+	fb.names = append(fb.names, f...)
+	for i := range f {
+		b, err := ioutil.ReadFile(f[i])
+		if err != nil {
+			return err
+		}
+		fb.bytes = append(fb.bytes, b)
+	}
+	return nil
+}
+
+// String reports the original FileBytesArray filenames a string.
+func (fb FileBytesArray) String() string {
+	return strings.Join(fb.names, ",")
+}

--- a/flagx/filebytesarray_test.go
+++ b/flagx/filebytesarray_test.go
@@ -1,0 +1,65 @@
+package flagx_test
+
+import (
+	"flag"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/m-lab/go/rtx"
+
+	"github.com/m-lab/go/flagx"
+)
+
+func TestFileBytesArray(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		wantErr bool
+	}{
+		{
+			name:    "success",
+			content: "this is a test",
+		},
+		{
+			name:    "error-bad-filename",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var fname string
+			var f *os.File
+			var err error
+
+			if !tt.wantErr {
+				f, err = ioutil.TempFile("", "-filebytes")
+				rtx.Must(err, "Failed to create tempfile")
+				defer os.Remove(f.Name())
+				f.WriteString(tt.content)
+				fname = f.Name()
+				f.Close()
+			} else {
+				fname = "this-is-not-a-file"
+			}
+
+			fb := &flagx.FileBytesArray{}
+			if err := fb.Set(fname); (err != nil) != tt.wantErr {
+				t.Errorf("FileBytesArray.Set() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			data := fb.Get()
+			if !tt.wantErr && tt.content != string(data[0]) {
+				t.Errorf("FileBytesArray.Get() want = %q, got %q", tt.content, string(data[0]))
+			}
+			if !tt.wantErr && fname != fb.String() {
+				t.Errorf("FileBytesArray.String() want = %q, got %q", tt.content, fb.String())
+			}
+		})
+	}
+}
+
+// Successful compilation of this function means that FileBytes implements the
+// flag.Getter interface. The function need not be called.
+func assertFlagGetterFileBytesArray(b flagx.FileBytesArray) {
+	func(in flag.Value) {}(&b)
+}


### PR DESCRIPTION
This PR adds a new flagx type for FileBytesArrays. This type combines the semantics of StringArray and FileBytes.

The goals is to add a flag that accepts multiple file names and reads the content of each. The first use case for this flag is the ndt-server loading multiple verify keys to permit key rotation of the locate service access tokens.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/go/117)
<!-- Reviewable:end -->
