### PR TITLE
Add support for BMC hostnames (mlab[1-4]d)

### DIFF
--- a/host/host.go
+++ b/host/host.go
@@ -21,9 +21,9 @@ type Name struct {
 func Parse(name string) (Name, error) {
 	var parts Name
 
-	reInit := regexp.MustCompile(`^mlab[1-4]([.-])`)
-	reV1 := regexp.MustCompile(`^(mlab[1-4])\.([a-z]{3}[0-9tc]{2})\.(measurement-lab.org)$`)
-	reV2 := regexp.MustCompile(`^(mlab[1-4])-([a-z]{3}[0-9tc]{2})\.(.*?)\.(measurement-lab.org)$`)
+	reInit := regexp.MustCompile(`^mlab[1-4]d?([.-])`)
+	reV1 := regexp.MustCompile(`^(mlab[1-4]d?)\.([a-z]{3}[0-9tc]{2})\.(measurement-lab.org)$`)
+	reV2 := regexp.MustCompile(`^(mlab[1-4]d?)-([a-z]{3}[0-9tc]{2})\.(.*?)\.(measurement-lab.org)$`)
 
 	mInit := reInit.FindAllStringSubmatch(name, -1)
 	if len(mInit) != 1 || len(mInit[0]) != 2 {

--- a/host/host_test.go
+++ b/host/host_test.go
@@ -35,6 +35,17 @@ func TestName(t *testing.T) {
 			},
 		},
 		{
+			name:     "valid-v2-bmc",
+			hostname: "mlab1d-lol01.mlab-oti.measurement-lab.org",
+			want: Name{
+				Machine: "mlab1d",
+				Site:    "lol01",
+				Project: "mlab-oti",
+				Domain:  "measurement-lab.org",
+				Version: "v2",
+			},
+		},
+		{
 			name:     "invalid-v1-bad-separator",
 			hostname: "mlab1=lol01.measurement-lab.org",
 			want:     Name{},


### PR DESCRIPTION
This PR adds support for BMC hostnames so that the `Parse()` function can be used for those, too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/go/118)
<!-- Reviewable:end -->
