### PR TITLE
Allow Parse to accept service names, add String to reconstruct name

### DIFF
--- a/host/host_test.go
+++ b/host/host_test.go
@@ -46,6 +46,48 @@ func TestName(t *testing.T) {
 			},
 		},
 		{
+			name:     "valid-v1-with-ndt-flat",
+			hostname: "ndt-iupui-mlab1-lol01.measurement-lab.org",
+			want: Name{
+				Machine: "mlab1",
+				Site:    "lol01",
+				Domain:  "measurement-lab.org",
+				Version: "v1",
+			},
+		},
+		{
+			name:     "valid-v1-with-ndt-regular",
+			hostname: "ndt.iupui.mlab1.lol01.measurement-lab.org",
+			want: Name{
+				Machine: "mlab1",
+				Site:    "lol01",
+				Domain:  "measurement-lab.org",
+				Version: "v1",
+			},
+		},
+		{
+			name:     "valid-v2-with-ndt",
+			hostname: "ndt-iupui-mlab1-lol01.mlab-oti.measurement-lab.org",
+			want: Name{
+				Machine: "mlab1",
+				Site:    "lol01",
+				Project: "mlab-oti",
+				Domain:  "measurement-lab.org",
+				Version: "v2",
+			},
+		},
+		{
+			name:     "valid-v2-with-ndt-short",
+			hostname: "ndt-mlab1-lol01.mlab-oti.measurement-lab.org",
+			want: Name{
+				Machine: "mlab1",
+				Site:    "lol01",
+				Project: "mlab-oti",
+				Domain:  "measurement-lab.org",
+				Version: "v2",
+			},
+		},
+		{
 			name:     "invalid-v1-bad-separator",
 			hostname: "mlab1=lol01.measurement-lab.org",
 			want:     Name{},


### PR DESCRIPTION
This change preserves existing functionality and adds two new features.

1. Parse() now accepts service names, such as those returned by mlab-ns, discards the service portion and parses the remaining machine name.

2. String() reconstructs the hostname based on the Version and other fields.

Previously, we had left out a `String()` function, reasoning that the caller already has the machine name. However, a new use case is when we want to create a v1 and a v2 machine name. The String function allows that.

These changes will allow the locate service to remain agnostic to the hostnames returned by mlab-ns while still supporting both v1 and v2 hostnames in the access tokens that it issues.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/go/119)
<!-- Reviewable:end -->
