### PR TITLE
Fix upstream location of promlint

### DIFF
--- a/prometheusx/promtest/promtest.go
+++ b/prometheusx/promtest/promtest.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/m-lab/go/prometheusx"
 	"github.com/m-lab/go/rtx"
-	"github.com/prometheus/prometheus/util/promlint"
+	"github.com/prometheus/client_golang/prometheus/testutil/promlint"
 )
 
 // LintMetrics will ensure that the names of the passed-in Promethus metrics


### PR DESCRIPTION
Recent upstream changes to prometheus repo have broken dependencies on the promlint package. This fixes it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/go/121)
<!-- Reviewable:end -->
