### PR TITLE
Mark all fields as nullable

### DIFF
--- a/cloud/bqx/schema.go
+++ b/cloud/bqx/schema.go
@@ -128,13 +128,8 @@ func RemoveRequired(schema bigquery.Schema) bigquery.Schema {
 			fs.Required = false
 			fs.Schema = RemoveRequired(fs.Schema)
 
-		// These field types seem to be always required.
-		case bigquery.TimeFieldType:
-		case bigquery.TimestampFieldType:
-		case bigquery.DateFieldType:
-		case bigquery.DateTimeFieldType:
-
 		default:
+			// Mark all fields as nullable.
 			fs.Required = false
 		}
 	}

--- a/cloud/bqx/schema_test.go
+++ b/cloud/bqx/schema_test.go
@@ -67,7 +67,7 @@ func TestRemoveRequired(t *testing.T) {
 	expect(t, s, `"Repeated":true`, 1) // From the ByteArray
 
 	c := bqx.RemoveRequired(s)
-	expect(t, c, `"Required":true`, 1)
+	expect(t, c, `"Required":true`, 0)
 }
 
 func TestCustomize(t *testing.T) {


### PR DESCRIPTION
This change marks all fields nullable, including timestamps.

This appears to wai. Tables with all NULLABLE records appear to be updatable by schemas with all NULLABLE records.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/go/122)
<!-- Reviewable:end -->
