### PR TITLE
Add flagx.Advanced variable and first advanced flag -httpx.tcp-network

### DIFF
--- a/flagx/advanced.go
+++ b/flagx/advanced.go
@@ -1,0 +1,20 @@
+package flagx
+
+import "flag"
+
+var (
+	// Advanced is a *flag.FlagSet for advanced flags. Packages should add flags
+	// to Advanced when those flags should NOT be included in the default
+	// flag.CommandLine flag set. Advanced flags may be enabled by calling
+	// EnableAdvancedFlags _before_ calling flag.Parse().
+	Advanced = flag.NewFlagSet("advanced", flag.ExitOnError)
+)
+
+// EnableAdvancedFlags adds all flags registered with the Advanced flag set to
+// the default flag.CommandLine flag set. EnableAdvancedFlags should be called
+// before flag.Parse().
+func EnableAdvancedFlags() {
+	Advanced.VisitAll(func(f *flag.Flag) {
+		flag.Var(f.Value, f.Name, f.Usage)
+	})
+}

--- a/flagx/advanced_test.go
+++ b/flagx/advanced_test.go
@@ -1,0 +1,47 @@
+package flagx
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/go-test/deep"
+)
+
+func TestEnableAdvancedFlags(t *testing.T) {
+	t.Run("example", func(t *testing.T) {
+		// Add advanced flags.
+		e := Enum{
+			Options: []string{"a", "b"},
+			Value:   "b",
+		}
+		s := "advanced"
+		Advanced.Var(&e, "advanced-enum-flag", "advanced-usage")
+		Advanced.StringVar(&s, "advanced-string-flag", "", "advanced-usage")
+
+		// Add default flags.
+		// Reset the default command line flag to simplilfy checking tests.
+		flag.CommandLine = flag.NewFlagSet("default", flag.ContinueOnError)
+		s2 := "default"
+		flag.StringVar(&s2, "default-flag", "", "default-usage")
+
+		// Add advanced flags to default set.
+		EnableAdvancedFlags()
+
+		found := map[string]bool{}
+		expected := map[string]bool{
+			"advanced-enum-flag":   true,
+			"advanced-string-flag": true,
+			"default-flag":         true,
+		}
+		// Verify that they are present in the default set now.
+		flag.CommandLine.VisitAll(
+			func(f *flag.Flag) {
+				found[f.Name] = true
+				t.Logf("Found: %q", f.Name)
+			},
+		)
+		if diff := deep.Equal(found, expected); diff != nil {
+			t.Errorf("EnableAdvancedFlags() found the wrong advanced flags: %#v", diff)
+		}
+	})
+}

--- a/httpx/httpx.go
+++ b/httpx/httpx.go
@@ -17,6 +17,10 @@ import (
 
 var logFatalf = log.Fatalf
 
+// DefaultTCPNetwork defines the TCP network used by ListenAndServeAsync and
+// ListenAndServeTLSAsync HTTP(S) servers. See https://golang.org/pkg/net/#Dial
+var DefaultTCPNetwork = "tcp"
+
 // The code here is adapted from https://golang.org/src/net/http/server.go?s=85391:85432#L2742
 
 // tcpKeepAliveListener sets TCP keep-alive timeouts on accepted
@@ -56,7 +60,7 @@ func serve(server *http.Server, listener net.Listener) {
 // contain the address and port which this server is listening on.
 func ListenAndServeAsync(server *http.Server) error {
 	// Start listening synchronously.
-	listener, err := net.Listen("tcp", server.Addr)
+	listener, err := net.Listen(DefaultTCPNetwork, server.Addr)
 	if err != nil {
 		return err
 	}
@@ -87,7 +91,7 @@ func serveTLS(server *http.Server, listener net.Listener, certFile, keyFile stri
 // fatal error if the server dies for a reason besides ErrServerClosed.
 func ListenAndServeTLSAsync(server *http.Server, certFile, keyFile string) error {
 	// Start listening synchronously.
-	listener, err := net.Listen("tcp", server.Addr)
+	listener, err := net.Listen(DefaultTCPNetwork, server.Addr)
 	if err != nil {
 		return err
 	}

--- a/httpx/httpx.go
+++ b/httpx/httpx.go
@@ -13,13 +13,23 @@ import (
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/m-lab/go/flagx"
 )
 
 var logFatalf = log.Fatalf
 
-// DefaultTCPNetwork defines the TCP network used by ListenAndServeAsync and
+// tcpNetwork defines the TCP network used by ListenAndServeAsync and
 // ListenAndServeTLSAsync HTTP(S) servers. See https://golang.org/pkg/net/#Dial
-var DefaultTCPNetwork = "tcp"
+var tcpNetwork = flagx.Enum{
+	Options: []string{"tcp", "tcp4", "tcp6"},
+	Value:   "tcp",
+}
+
+func init() {
+	// Add as an advanced flag.
+	flagx.Advanced.Var(&tcpNetwork, "httpx.tcp-network", "Controls the TCP stack used by httpx net.Listeners")
+}
 
 // The code here is adapted from https://golang.org/src/net/http/server.go?s=85391:85432#L2742
 
@@ -60,7 +70,7 @@ func serve(server *http.Server, listener net.Listener) {
 // contain the address and port which this server is listening on.
 func ListenAndServeAsync(server *http.Server) error {
 	// Start listening synchronously.
-	listener, err := net.Listen(DefaultTCPNetwork, server.Addr)
+	listener, err := net.Listen(tcpNetwork.Value, server.Addr)
 	if err != nil {
 		return err
 	}
@@ -91,7 +101,7 @@ func serveTLS(server *http.Server, listener net.Listener, certFile, keyFile stri
 // fatal error if the server dies for a reason besides ErrServerClosed.
 func ListenAndServeTLSAsync(server *http.Server, certFile, keyFile string) error {
 	// Start listening synchronously.
-	listener, err := net.Listen(DefaultTCPNetwork, server.Addr)
+	listener, err := net.Listen(tcpNetwork.Value, server.Addr)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This change adds a package variable that declares the "default tcp network" to use when creating a listener for the http server functions.

This change allows callers to pin the network to either "tcp4", "tcp6", or continue using the default "tcp" (dual stack).

The first use case for this functionality will be the access envelope.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/go/123)
<!-- Reviewable:end -->
