### PR TITLE
Add flagx.File type

### DIFF
--- a/flagx/file.go
+++ b/flagx/file.go
@@ -1,0 +1,42 @@
+package flagx
+
+import (
+	"io/ioutil"
+)
+
+// File is a new flag type. For a given filename, File reads and saves the file
+// content to Bytes and the original filename to Name. Errors opening or
+// reading the file are handled during flag parsing.
+type File struct {
+	Bytes []byte
+	Name  string
+}
+
+// Get retrieves the bytes read from the file.
+func (fb *File) Get() []byte {
+	return fb.Bytes
+}
+
+// Content retrieves the bytes read from the file as a string.
+func (fb *File) Content() string {
+	return string(fb.Bytes)
+}
+
+// Set accepts a file name. On success, the file content is saved to Bytes, and
+// the original file name to Name.
+func (fb *File) Set(s string) error {
+	b, err := ioutil.ReadFile(s)
+	if err != nil {
+		return err
+	}
+	fb.Name = s
+	fb.Bytes = b
+	return nil
+}
+
+// String reports the original file Name. NOTE: String is typically used by the
+// flag help text and to report flag values. To return the file content as a
+// string, see File.Content().
+func (fb *File) String() string {
+	return fb.Name
+}

--- a/flagx/file_test.go
+++ b/flagx/file_test.go
@@ -1,0 +1,67 @@
+package flagx_test
+
+import (
+	"flag"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/m-lab/go/rtx"
+
+	"github.com/m-lab/go/flagx"
+)
+
+func TestFile(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		wantErr bool
+	}{
+		{
+			name:    "okay",
+			content: "1234567890abcdef",
+		},
+		{
+			name:    "error-bad-filename",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var fname string
+			var f *os.File
+			var err error
+
+			if !tt.wantErr {
+				f, err = ioutil.TempFile("", "filebytes-*")
+				rtx.Must(err, "Failed to create tempfile")
+				defer os.Remove(f.Name())
+				f.WriteString(tt.content)
+				fname = f.Name()
+				f.Close()
+			} else {
+				fname = "this-is-not-a-file"
+			}
+
+			fb := flagx.File{}
+			if err := fb.Set(fname); (err != nil) != tt.wantErr {
+				t.Errorf("File.Set() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr && tt.content != string(fb.Get()) {
+				t.Errorf("File.Get() want = %q, got %q", tt.content, string(fb.Get()))
+			}
+			if !tt.wantErr && tt.content != fb.Content() {
+				t.Errorf("File.Get() want = %q, got %q", tt.content, fb.Content())
+			}
+			if !tt.wantErr && fname != fb.String() {
+				t.Errorf("File.String() want = %q, got %q", fname, fb.String())
+			}
+		})
+	}
+}
+
+// Successful compilation of this function means that File implements the
+// flag.Value interface. The function need not be called.
+func assertFlagValue(b flagx.File) {
+	func(in flag.Value) {}(&b)
+}


### PR DESCRIPTION
This change introduces a new flag type `flagx.File` that preserves the file name during flag handling and should eventually replace `flagx.FileBytes`.

In my own experience and two recent PRs (https://github.com/m-lab/measure-saver/pull/7 & https://github.com/m-lab/alertmanager-github-receiver/pull/44 ) it would be more helpful for the file name to be displayed by the flag processing logic, rather than the file contents. The `flagx.FileBytesArray` introduced this idea. This change adds a new flag type that exposes both the `File.Bytes` and the `File.Name`.

This change introduces a new type rather than modifying FileBytes because the shorter name better represents the flag purpose, and prevents the naming stutter of `FileBytes.Bytes`, as well, this preserves compatibility with existing users of the `flagx.FileBytes` type until they can be migrated to this replacement.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/go/124)
<!-- Reviewable:end -->
