### PR TITLE
Add testingx package with testingx.Must

### DIFF
--- a/testingx/testingx.go
+++ b/testingx/testingx.go
@@ -1,0 +1,37 @@
+package testingx
+
+import (
+	"fmt"
+)
+
+// FatalReporter defines the interface for reporting a fatal test.
+type FatalReporter interface {
+	Fatal(args ...interface{})
+	Helper()
+}
+
+// Must allows the rtx.Must pattern within a unit test and will call t.Fatal if
+// passed a non-nil error. The fatal message is specified as the prefix
+// argument. If any further args are passed, then the prefix will be treated as
+// a format string.
+//
+// The main purpose of this function is to turn the common pattern of:
+//    err := Func()
+//    if err != nil {
+//        t.Fatalf("Helpful message (error: %v)", err)
+//    }
+// into a simplified pattern of:
+//    Must(t, Func(), "Helpful message")
+//
+// This has the benefit of using fewer lines and verifying unit tests are
+// "correct by inspection".
+func Must(t FatalReporter, err error, prefix string, args ...interface{}) {
+	t.Helper() // Excludes this function from the line reported by t.Fatal.
+	if err != nil {
+		suffix := fmt.Sprintf(" (error: %v)", err)
+		if len(args) != 0 {
+			prefix = fmt.Sprintf(prefix, args...)
+		}
+		t.Fatal(prefix + suffix)
+	}
+}

--- a/testingx/testingx_test.go
+++ b/testingx/testingx_test.go
@@ -1,0 +1,30 @@
+package testingx
+
+import (
+	"errors"
+	"testing"
+)
+
+type fakeReporter struct {
+	called int
+}
+
+func (f *fakeReporter) Helper() {}
+func (f *fakeReporter) Fatal(args ...interface{}) {
+	f.called++
+}
+
+func TestMust(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		f := &fakeReporter{}
+		Must(f, nil, "print nothing")
+		if f.called != 0 {
+			t.Fatal("t.Fatal called with nil error!")
+		}
+		err := errors.New("fake error")
+		Must(f, err, "print nothing: %s", "custom args")
+		if f.called != 1 {
+			t.Fatal("t.Fatal NOT called with non-nil error!")
+		}
+	})
+}


### PR DESCRIPTION
This change adds a new package and function for `testingx.Must` -- this function provides similar behavior as `rtx.Must` while working natively with the `*testing.T` available during testing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/go/127)
<!-- Reviewable:end -->
