### PR TITLE
Add uploader package and update gcsfake to use it in testing

### DIFF
--- a/cloud/gcs/gcs_test.go
+++ b/cloud/gcs/gcs_test.go
@@ -20,9 +20,9 @@ func init() {
 }
 
 func TestHasFiles(t *testing.T) {
-	fc := gcsfake.GCSClient{}
+	fc := &gcsfake.GCSClient{}
 	fc.AddTestBucket("foobar",
-		gcsfake.BucketHandle{
+		&gcsfake.BucketHandle{
 			ObjAttrs: []*storage.ObjectAttrs{
 				{Name: "ndt/2019/01/01/obj1", Size: 101, Updated: time.Now()},
 				{Name: "ndt/2019/01/01/obj2", Size: 2020, Updated: time.Now()},
@@ -39,9 +39,9 @@ func TestHasFiles(t *testing.T) {
 }
 
 func TestGetFilesSince(t *testing.T) {
-	fc := gcsfake.GCSClient{}
+	fc := &gcsfake.GCSClient{}
 	fc.AddTestBucket("foobar",
-		gcsfake.BucketHandle{
+		&gcsfake.BucketHandle{
 			ObjAttrs: []*storage.ObjectAttrs{
 				{Name: "ndt/2019/01/01/obj1", Size: 101, Updated: time.Now()},
 				{Name: "ndt/2019/01/01/obj2", Size: 2020, Updated: time.Now()},
@@ -66,9 +66,9 @@ func TestGetFilesSince(t *testing.T) {
 }
 
 func TestGetFilesSince_Context(t *testing.T) {
-	fc := gcsfake.GCSClient{}
+	fc := &gcsfake.GCSClient{}
 	fc.AddTestBucket("foobar",
-		gcsfake.BucketHandle{
+		&gcsfake.BucketHandle{
 			ObjAttrs: []*storage.ObjectAttrs{
 				{Name: "ndt/2019/01/01/obj1", Size: 101, Updated: time.Now()},
 			}})

--- a/cloudtest/gcsfake/gcsfake_test.go
+++ b/cloudtest/gcsfake/gcsfake_test.go
@@ -48,7 +48,7 @@ func TestGCSClient(t *testing.T) {
 
 	fc := gcsfake.GCSClient{}
 	fc.AddTestBucket("foobar",
-		gcsfake.BucketHandle{
+		&gcsfake.BucketHandle{
 			ObjAttrs: []*storage.ObjectAttrs{
 				{Name: "ndt/2019/01/01/obj1", Updated: time.Now()},
 				{Name: "ndt/2019/01/01/obj2", Updated: time.Now()},

--- a/uploader/uploader.go
+++ b/uploader/uploader.go
@@ -1,0 +1,36 @@
+package uploader
+
+import (
+	"bytes"
+	"context"
+	"io"
+
+	"github.com/googleapis/google-cloud-go-testing/storage/stiface"
+)
+
+// Uploader is a Google Cloud Storage uploader.
+type Uploader struct {
+	client stiface.Client
+	bucket stiface.BucketHandle
+}
+
+// New returns a new Uploader using the specified Client.
+func New(client stiface.Client, bucket string) *Uploader {
+	return &Uploader{
+		client: client,
+		bucket: client.Bucket(bucket),
+	}
+}
+
+// Upload uploads the provided buffer to the specified GCS path.
+func (u *Uploader) Upload(ctx context.Context, path string, content []byte) (stiface.ObjectHandle, error) {
+	obj := u.bucket.Object(path)
+	w := obj.NewWriter(ctx)
+	defer w.Close()
+
+	_, err := io.Copy(w, bytes.NewBuffer(content))
+	if err != nil {
+		return nil, err
+	}
+	return obj, nil
+}

--- a/uploader/uploader_test.go
+++ b/uploader/uploader_test.go
@@ -1,0 +1,89 @@
+package uploader
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/googleapis/google-cloud-go-testing/storage/stiface"
+	"github.com/m-lab/go/cloudtest/gcsfake"
+)
+
+func TestNew(t *testing.T) {
+	client := &gcsfake.GCSClient{}
+	u := New(client, "bucket_name")
+	if u == nil {
+		t.Errorf("New() returned nil")
+	}
+}
+
+func TestUploader_Upload(t *testing.T) {
+	type fields struct {
+		client stiface.Client
+		bucket stiface.BucketHandle
+	}
+	type args struct {
+		ctx     context.Context
+		path    string
+		content []byte
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "ok",
+			fields: fields{
+				bucket: &gcsfake.BucketHandle{
+					Objs: make(map[string]*gcsfake.ObjectHandle, 0),
+				},
+			},
+			args: args{
+				ctx:     context.Background(),
+				content: []byte("test"),
+				path:    "this/is/a/test",
+			},
+		},
+		{
+			name: "write-fails",
+			fields: fields{
+				bucket: &gcsfake.BucketHandle{
+					Objs:           make(map[string]*gcsfake.ObjectHandle, 0),
+					WritesMustFail: true,
+				},
+			},
+			args: args{
+				ctx:     context.Background(),
+				content: []byte("failing write"),
+				path:    "this/is/a/test",
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			u := &Uploader{
+				client: tt.fields.client,
+				bucket: tt.fields.bucket,
+			}
+			obj, err := u.Upload(tt.args.ctx, tt.args.path, tt.args.content)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Uploader.Upload() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err == nil && obj == nil {
+				t.Errorf("Uploader.Upload() returned a nil object.")
+			}
+			// Check uploaded content.
+			if err == nil {
+				if bucket, ok := tt.fields.bucket.(*gcsfake.BucketHandle); ok {
+					uploaded := bucket.Objs[tt.args.path]
+					if !reflect.DeepEqual(uploaded.Data.Bytes(), tt.args.content) {
+						t.Errorf("Uploader.Upload() didn't upload the expected data")
+					}
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR introduces an `uploader` package, to upload data to a Google Cloud Storage bucket, and makes the necessary changes so that the `cloudtest/gcsfake` package can be used to test it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/go/128)
<!-- Reviewable:end -->
