### PR TITLE
Add shx.Job interface with State, Description, and ExecJob

### DIFF
--- a/shx/job.go
+++ b/shx/job.go
@@ -1,0 +1,251 @@
+// Package shx provides shell-like operations for Go.
+//
+// A Job represents one or more operations. A single-operation Job may represent
+// running a command (Exec, System), or reading or writing a file (ReadFile,
+// WriteFile), or a user defined operation (Func). A multiple-operation Job runs
+// several single operation jobs in a sequence (Script) or pipeline (Pipe).
+// Taken together, these primitive types allow the composition of more and more
+// complex operations.
+//
+// Users control how a Job runs using State. State controls the Job input and
+// output, as well as its working directory and environment.
+//
+// Users may produce a human-readable representation of a complex Job in a
+// shell-like syntax using the Description. Because some operations have no
+// shell equivalent, the result is only representative.
+//
+// Examples are provided for all primitive Job types: Exec, System, Func, Pipe,
+// Script. Additional convenience Jobs make creating more complex operations a
+// little easier. Advanced users may create their own Job types for more
+// flexibility.
+package shx
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// Description is used to produce a representation of a Job. Custom Job types
+// should use the Description interface to represent their behavior in a
+// helpful, human-readable form. After collecting a description, serialize using
+// the String() method.
+type Description struct {
+	// Depth is used to control line prefix indentation in complex Jobs.
+	Depth int
+	desc  bytes.Buffer
+	line  int
+	seps  []string
+	idxs  []int
+}
+
+// Append adds a new command to the output buffer. Typically, the command is
+// formatted as a new line at the end of the current buffer. If StartSequence
+// was called before calling Append, then the command is formatted as a
+// continuation of the current line.
+func (d *Description) Append(cmd string) {
+	l := len(d.idxs)
+	if l > 0 {
+		d.idxs[l-1]++
+		if d.idxs[l-1] > 1 {
+			// After the first cmd, separate others with a separator.
+			d.desc.WriteString(d.seps[l-1] + cmd)
+			return
+		}
+		d.desc.WriteString(cmd)
+		return
+	}
+	d.line++
+	d.desc.WriteString(fmt.Sprintf("%2d: %s%s\n", d.line, prefix(d.Depth), cmd))
+}
+
+// StartSequence begins formatting a multi-part expression on a single line,
+// such as a list, pipeline, or similar expression. StartSequence begins with
+// "start" and subsequent calls to Append add commands to the end of the current
+// line, separating sequential commands with "sep". StartSequence returns a
+// function that ends the line and restores the default behavior of Append.
+func (d *Description) StartSequence(start, sep string) (endlist func(end string)) {
+	d.seps = append(d.seps, sep)
+	d.idxs = append(d.idxs, 0)
+	l := len(d.idxs)
+	if l == 1 {
+		d.line++
+		d.desc.WriteString(fmt.Sprintf("%2d: %s", d.line, prefix(d.Depth)))
+	}
+	if l > 1 {
+		// For deeper nesting, use the prior separator prior to current start.
+		d.desc.WriteString(d.seps[l-2])
+	}
+	d.desc.WriteString(start)
+	endlist = func(end string) {
+		l := len(d.idxs)
+		// Verify that some commands were printed before adding extra newline.
+		d.desc.WriteString(end)
+		if l == 1 {
+			d.desc.WriteString("\n")
+		}
+		d.seps = d.seps[:len(d.seps)-1]
+		d.idxs = d.idxs[:len(d.idxs)-1]
+	}
+	return endlist
+}
+
+// String serializes a description produced by running Job.Describe(). Calling
+// String resets the Description buffer.
+func (d *Description) String() string {
+	s := d.desc.String()
+	d.desc.Reset()
+	return s
+}
+
+// State is a Job configuration. Callers provide the first initial State, and
+// as a Job executes it creates new State instances derived from the original,
+// e.g. for Pipes and subcommands.
+type State struct {
+	Stdin  io.Reader
+	Stdout io.Writer
+	Stderr io.Writer
+	Dir    string
+	Env    []string
+}
+
+// New creates a State instance based on the current process state, using
+// os.Stdin, os.Stdout, and os.Stderr, as well as the current working directory
+// and environment.
+func New() *State {
+	d, _ := os.Getwd()
+	s := &State{
+		Stdin:  os.Stdin,
+		Stdout: os.Stdout,
+		Stderr: os.Stderr,
+		Dir:    d,
+		Env:    os.Environ(),
+	}
+	return s
+}
+
+func prefix(d int) string {
+	v := ""
+	for i := 0; i < d; i++ {
+		v = v + "  "
+	}
+	return v
+}
+
+// SetDir assigns the Dir value and returns the previous value.
+func (s *State) SetDir(dir string) string {
+	prev := s.Dir
+	s.Dir = dir
+	return prev
+}
+
+// Path produces a path relative to the State's current directory. If arguments
+// represent an absolute path, then that is used. If multiple arguments are
+// provided, they're joined using filepath.Join.
+func (s *State) Path(path ...string) string {
+	if len(path) == 0 {
+		return s.Dir
+	}
+	if filepath.IsAbs(path[0]) {
+		return filepath.Join(path...)
+	}
+	if len(path) == 1 {
+		return filepath.Join(s.Dir, path[0])
+	}
+	return filepath.Join(append([]string{s.Dir}, path...)...)
+}
+
+// SetEnv assigns the named variable to the given value in the State
+// environment. If the named variable is already defined it is overwritten.
+func (s *State) SetEnv(name, value string) {
+	prefix := name + "="
+	// Find and overwrite an existing value.
+	for i, kv := range s.Env {
+		if strings.HasPrefix(kv, prefix) {
+			s.Env[i] = prefix + value
+			return
+		}
+	}
+	// Or, add the new value to the s.Env.
+	s.Env = append(s.Env, prefix+value)
+}
+
+// GetEnv reads the named variable from the State environment. If name is not
+// found, an empty value is returned. An undefined variable and a variable set
+// to the empty value are indistinguishable.
+func (s *State) GetEnv(name string) string {
+	prefix := name + "="
+	for _, kv := range s.Env {
+		if strings.HasPrefix(kv, prefix) {
+			return strings.TrimPrefix(kv, prefix)
+		}
+	}
+	// name not found.
+	return ""
+}
+
+// Job is the interface for an operation. A Job controls how an operation is run
+// and represented.
+type Job interface {
+	// Describe produces a readable representation of the Job operation. After
+	// calling Describe, use Description.String() to report the result.
+	Describe(d *Description)
+
+	// Run executes the Job using the given State. A Job should terminate when
+	// the given context is cancelled.
+	Run(ctx context.Context, s *State) error
+}
+
+// Exec creates a Job to execute the given command with the given arguments.
+func Exec(cmd string, args ...string) *ExecJob {
+	return &ExecJob{
+		name: cmd,
+		args: args,
+	}
+}
+
+// System is an Exec job that interprets the given command using "/bin/sh".
+func System(cmd string) *ExecJob {
+	return &ExecJob{
+		name: "/bin/sh",
+		args: []string{"-c", cmd},
+	}
+}
+
+// ExecJob implements the Job interface for basic process execution.
+type ExecJob struct {
+	name string
+	args []string
+}
+
+// Run executes the command.
+func (f *ExecJob) Run(ctx context.Context, s *State) error {
+	cmd := exec.CommandContext(ctx, f.name, f.args...)
+	cmd.Dir = s.Dir
+	cmd.Env = s.Env
+	cmd.Stdin = s.Stdin
+	cmd.Stdout = s.Stdout
+	cmd.Stderr = s.Stderr
+	err := cmd.Start()
+	if err != nil {
+		return err
+	}
+	if err := cmd.Wait(); err != nil {
+		return fmt.Errorf("%w: %s %s", err, f.name, strings.Join(f.args, " "))
+	}
+	return nil
+}
+
+// Describe generates a description for this command.
+func (f *ExecJob) Describe(d *Description) {
+	args := ""
+	if len(f.args) > 0 {
+		args = " " + strings.Join(f.args, " ")
+	}
+	d.Append(f.name + args)
+}

--- a/shx/job_test.go
+++ b/shx/job_test.go
@@ -1,0 +1,242 @@
+package shx_test
+
+import (
+	"bytes"
+	"context"
+	"log"
+	"os"
+	"testing"
+
+	. "github.com/m-lab/go/shx"
+)
+
+func init() {
+	log.SetFlags(log.LUTC | log.Llongfile)
+}
+
+func TestDescription(t *testing.T) {
+	tests := []struct {
+		name  string
+		lines []string
+		cmds  []string
+		want  string
+	}{
+		{
+			name:  "success-script",
+			lines: []string{"env", "pwd"},
+			want:  " 1: env\n 2: pwd\n 3: \n",
+		},
+		{
+			name: "success-pipe",
+			cmds: []string{"env", "cat"},
+			want: " 1: env | cat\n",
+		},
+		{
+			name:  "success-script-pipe",
+			lines: []string{"env", "pwd"},
+			cmds:  []string{"env", "cat"},
+			want:  " 1: env\n 2: pwd\n 3: env | cat\n",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := &Description{}
+			for _, line := range tt.lines {
+				d.Append(line)
+			}
+			endlist := d.StartSequence("", " | ")
+			for _, cmd := range tt.cmds {
+				d.Append(cmd)
+			}
+			endlist("")
+			v := d.String()
+			if v != tt.want {
+				t.Errorf("Description: wrong result; got %q, want %q", v, tt.want)
+			}
+		})
+	}
+}
+
+func TestExec(t *testing.T) {
+	tests := []struct {
+		name    string
+		cmd     string
+		args    []string
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "success",
+			cmd:  "/bin/echo",
+			args: []string{"a", "b"},
+			want: "a b\n",
+		},
+		{
+			name:    "error-no-such-command",
+			cmd:     "/not-a-dir/not-a-real-command",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			job := Exec(tt.cmd, tt.args...)
+			ctx := context.Background()
+			b := bytes.NewBuffer(nil)
+			s := &State{
+				Stdout: b,
+			}
+			err := job.Run(ctx, s)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Exec() = %v, want %t", err, tt.wantErr)
+			}
+			if b.String() != tt.want {
+				t.Errorf("Exec() = got %v, want %v", b.String(), tt.want)
+			}
+		})
+	}
+}
+
+func TestState(t *testing.T) {
+	t.Run("SetState", func(t *testing.T) {
+		s := New()
+		origDir := s.Dir
+		if p := s.SetDir("/"); p != origDir {
+			t.Errorf("SetDir() wrong previous value; got %q, want %q", p, origDir)
+		}
+		s.SetEnv("FOO", "BAR")
+		if p := s.GetEnv("FOO"); p != "BAR" {
+			t.Errorf("SetEnv() found wrong value; got %q, want %q", p, "BAR")
+		}
+		// Set the same variable with a new value.
+		s.SetEnv("FOO", "BAR2")
+		if p := s.GetEnv("FOO"); p != "BAR2" {
+			t.Errorf("SetEnv() found wrong value; got %q, want %q", p, "BAR2")
+		}
+		if p := s.GetEnv("NOTFOUND"); p != "" {
+			t.Errorf("GetEnv() found value; got %q, want %q", p, "")
+		}
+		if p := s.Path(); p != "/" {
+			t.Errorf("Path() wrong value; got %q, want %q", p, "/")
+		}
+		if p := s.Path("/"); p != "/" {
+			t.Errorf("Path() wrong value; got %q, want %q", p, "/")
+		}
+		if p := s.Path("relative"); p != "/relative" {
+			t.Errorf("Path() wrong value; got %q, want %q", p, "/relative")
+		}
+		if p := s.Path("relative", "path"); p != "/relative/path" {
+			t.Errorf("Path() wrong value; got %q, want %q", p, "/relative/path")
+		}
+	})
+}
+
+func TestDescribe(t *testing.T) {
+	tests := []struct {
+		name string
+		job  Job
+		want string
+	}{
+		{
+			name: "exec-name-only",
+			job:  Exec("ls"),
+			want: " 1: ls\n",
+		},
+		{
+			name: "exec-name-with-args",
+			job:  Exec("ls", "-l"),
+			want: " 1: ls -l\n",
+		},
+		{
+			name: "system-with-args",
+			job:  System("ls -l"),
+			want: " 1: /bin/sh -c ls -l\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := &Description{}
+			tt.job.Describe(d)
+			val := d.String()
+
+			if val != tt.want {
+				t.Errorf("Job.Describe() unexpected; got = %q, want %q", val, tt.want)
+			}
+		})
+	}
+}
+
+func TestRun(t *testing.T) {
+	tests := []struct {
+		name    string
+		job     Job
+		want    string
+		wantDir string
+		wantEnv string
+		wantErr bool
+	}{
+		{
+			name: "exec-echo",
+			job:  Exec("echo", "ok"),
+			want: "ok\n",
+		},
+		{
+			name:    "exec-error",
+			job:     Exec("/this-command-does-not-exist", "ok"),
+			wantErr: true,
+		},
+		{
+			name:    "system-error",
+			job:     System("exit 1"),
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := &bytes.Buffer{}
+			s := &State{
+				Stdout: b,
+			}
+			ctx := context.Background()
+			err := tt.job.Run(ctx, s)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Job.Run() unexpected error; got = %v, wantErr %t", err, tt.wantErr)
+			}
+			if s.Dir != tt.wantDir {
+				t.Errorf("Job.Run() unexpected Dir; got = %q, want %q", s.Dir, tt.wantDir)
+			}
+			val := b.String()
+			if val != tt.want {
+				t.Errorf("Job.Run() unexpected output; got = %q, want %q", val, tt.want)
+			}
+			if s.GetEnv("key") != tt.wantEnv {
+				t.Errorf("Job.Run() unexpected output; got = %q, want %q", val, tt.wantEnv)
+			}
+		})
+	}
+}
+
+func ExampleExecJob_Run() {
+	ex := Exec("echo", "a", "b")
+	s := &State{
+		Stdout: os.Stdout,
+	}
+	err := ex.Run(context.Background(), s)
+	if err != nil {
+		panic(err)
+	}
+	// Output: a b
+}
+
+func ExampleSystem() {
+	sys := System("echo a b")
+	s := &State{
+		Stdout: os.Stdout,
+	}
+	err := sys.Run(context.Background(), s)
+	if err != nil {
+		panic(err)
+	}
+	// Output: a b
+}


### PR DESCRIPTION
This change adds a new package `shx` that provides shell-like operations for Go. Ultimately, `shx` is intended to replace M-Lab's use of the `m-lab/pipe` package because this package is a modified fork of a 7 year old, unmaintained package from `github.com/go-pipe/pipe` with several limitations.

The `shx` package overcomes these limitations with the following features:

* Simpler implementation.
* Uses `context.Context` for job cancellation or limits.
* Provides full shell-like `Description` of jobs.
* Simple to define custom Job types that can be used with `shx` types.

This change is 1 of two or three to add more primitive types described in the package docstring: Exec, System, Func, Pipe, Script, with various convenience Jobs for common shell operations.