### PR TITLE
Add Func and Script Job types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@
 #
 language: go
 go:
-- "1.13"
+- "1.15"
 
 dist: xenial
 

--- a/shx/job.go
+++ b/shx/job.go
@@ -23,6 +23,7 @@ package shx
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -127,6 +128,18 @@ func New() *State {
 		Env:    os.Environ(),
 	}
 	return s
+}
+
+func (s *State) copy() *State {
+	c := &State{
+		Stdin:  s.Stdin,
+		Stdout: s.Stdout,
+		Stderr: s.Stderr,
+		Dir:    s.Dir,
+	}
+	// Make independent copy of environment.
+	c.Env = append(c.Env, s.Env...)
+	return c
 }
 
 func prefix(d int) string {
@@ -245,4 +258,137 @@ func (f *ExecJob) Describe(d *Description) {
 		args = " " + strings.Join(f.args, " ")
 	}
 	d.Append(f.name + args)
+}
+
+// Func creates a new FuncJob that runs the given function. Job functions should
+// honor the context to support cancelation. The given name is used to describe
+// this function.
+func Func(name string, job func(ctx context.Context, s *State) error) *FuncJob {
+	return &FuncJob{
+		Job: job,
+		Desc: func(d *Description) {
+			d.Append(name)
+		},
+	}
+}
+
+// FuncJob is a generic Job type that allows creating new operations without
+// creating a totally new type. When created directly, both Job and Desc fields
+// must be defined.
+type FuncJob struct {
+	Job  func(ctx context.Context, s *State) error
+	Desc func(d *Description)
+}
+
+// Run executes the job function.
+func (f *FuncJob) Run(ctx context.Context, s *State) error {
+	return f.Job(ctx, s)
+}
+
+// Describe generates a description for this custom function.
+func (f *FuncJob) Describe(d *Description) {
+	f.Desc(d)
+}
+
+// Chdir creates Job that changes the State Dir to the given directory at
+// runtime. This does not alter the process working directory. Chdir is helpful
+// in Script() Jobs.
+func Chdir(dir string) Job {
+	return &FuncJob{
+		Job: func(ctx context.Context, s *State) error {
+			s.Dir = s.Path(dir)
+			return nil
+		},
+		Desc: func(d *Description) {
+			d.Append(fmt.Sprintf("cd %s", dir))
+		},
+	}
+}
+
+// SetEnv creates a Job to assign the given name=value in the running State Env.
+// SetEnv is helpful in Script() Jobs.
+func SetEnv(name string, value string) Job {
+	return &FuncJob{
+		Job: func(ctx context.Context, s *State) error {
+			s.SetEnv(name, value)
+			return nil
+		},
+		Desc: func(d *Description) {
+			d.Append(fmt.Sprintf("export %s=%q", name, value))
+		},
+	}
+}
+
+// SetEnvFromJob creates a new Job that sets the given name in Env to the result
+// written to stdout by running the given Job. Errors from the given Job are
+// returned.
+func SetEnvFromJob(name string, job Job) Job {
+	return &FuncJob{
+		Job: func(ctx context.Context, s *State) error {
+			b := &bytes.Buffer{}
+			s2 := &State{
+				Stdout: b,
+				Env:    append([]string(nil), s.Env...),
+			}
+			err := job.Run(ctx, s2)
+			if err != nil {
+				return err
+			}
+			s.SetEnv(name, strings.TrimSpace(b.String()))
+			return nil
+		},
+		Desc: func(d *Description) {
+			close := d.StartSequence(fmt.Sprintf("export %s=$(", name), "")
+			job.Describe(d)
+			close(")")
+		},
+	}
+}
+
+// Script creates a Job that executes the given Job parameters in sequence. If
+// any Job returns an error, execution stops.
+func Script(t ...Job) *ScriptJob {
+	return &ScriptJob{
+		Jobs: t,
+	}
+}
+
+// ErrScriptError is a base Script error.
+var ErrScriptError = errors.New("script execution error")
+
+// ScriptJob implements the Job interface for running an ordered sequence of Jobs.
+type ScriptJob struct {
+	Jobs []Job
+}
+
+// Run sequentially executes every Job in the script. Any Job error stops
+// execution and generates an error describing the command that failed.
+func (c *ScriptJob) Run(ctx context.Context, s *State) error {
+	z := s.copy()
+	for i := range c.Jobs {
+		err := c.Jobs[i].Run(ctx, z)
+		// Special handling for script errors.
+		if err != nil && !errors.Is(err, ErrScriptError) {
+			d := &Description{}
+			c.Describe(d)
+			str := d.String()
+			return fmt.Errorf("%w:\n%s - %s", ErrScriptError, str, err.Error())
+		}
+		// All other errors.
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Describe generates a description for all jobs in the script.
+func (c *ScriptJob) Describe(d *Description) {
+	d.Append("(")
+	d.Depth++
+	for i := range c.Jobs {
+		c.Jobs[i].Describe(d)
+	}
+	d.Depth--
+	d.Append(")")
 }

--- a/shx/job.go
+++ b/shx/job.go
@@ -367,7 +367,7 @@ func (c *ScriptJob) Run(ctx context.Context, s *State) error {
 	z := s.copy()
 	for i := range c.Jobs {
 		err := c.Jobs[i].Run(ctx, z)
-		// Special handling for script errors.
+		// Only generate description when the error is NOT a script error.
 		if err != nil && !errors.Is(err, ErrScriptError) {
 			d := &Description{}
 			c.Describe(d)

--- a/shx/job_test.go
+++ b/shx/job_test.go
@@ -3,6 +3,9 @@ package shx_test
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
+	"fmt"
+	"io/ioutil"
 	"log"
 	"os"
 	"testing"
@@ -96,6 +99,98 @@ func TestExec(t *testing.T) {
 	}
 }
 
+func TestFunc(t *testing.T) {
+	count := 0
+	tests := []struct {
+		name string
+		job  func(ctx context.Context, s *State) error
+	}{
+		{
+			name: "success",
+			job:  func(ctx context.Context, s *State) error { count++; return nil },
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := Func(tt.name, tt.job)
+			ctx := context.Background()
+			s := &State{
+				Stdout: os.Stdout,
+			}
+			err := f.Run(ctx, s)
+			if err != nil {
+				t.Errorf("Func() failed; got %v, want nil", err)
+			}
+		})
+	}
+	if count != 1 {
+		t.Errorf("Func() count incorrect; got %d, want 1", count)
+	}
+}
+
+func TestScript(t *testing.T) {
+	tmpdir := t.TempDir()
+
+	tests := []struct {
+		name    string
+		t       []Job
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "success",
+			t: []Job{
+				Chdir(tmpdir),
+				System("pwd"),
+			},
+			want: tmpdir + "\n",
+		},
+		{
+			name: "stop-after-error",
+			t: []Job{
+				// Force an error.
+				System("exit 1"),
+				Func("test-failure", func(ctx context.Context, s *State) error {
+					t.Fatalf("script should not continue executing after error.")
+					return nil
+				}),
+			},
+			wantErr: true,
+		},
+		{
+			name: "stop-after-deep-error",
+			t: []Job{
+				// Force an error within a sub-Script.
+				Script(
+					System("exit 1"),
+				),
+				Func("test-failure", func(ctx context.Context, s *State) error {
+					t.Fatalf("script should not continue executing after error.")
+					return nil
+				}),
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			b := bytes.NewBuffer(nil)
+			s := &State{
+				Stdout: b,
+			}
+			sc := Script(tt.t...)
+			err := sc.Run(ctx, s)
+			if (err != nil) && !tt.wantErr {
+				t.Fatalf("failed to run test: %s", err)
+			}
+			if b.String() != tt.want {
+				t.Errorf("Script() wrong pwd output; got %s, want %s", b.String(), tt.want)
+			}
+		})
+	}
+}
+
 func TestState(t *testing.T) {
 	t.Run("SetState", func(t *testing.T) {
 		s := New()
@@ -147,9 +242,39 @@ func TestDescribe(t *testing.T) {
 			want: " 1: ls -l\n",
 		},
 		{
-			name: "system-with-args",
-			job:  System("ls -l"),
-			want: " 1: /bin/sh -c ls -l\n",
+			name: "func-simple",
+			job:  Func("simple", func(ctx context.Context, s *State) error { return nil }),
+			want: " 1: simple\n",
+		},
+		{
+			name: "func-custom",
+			job: &FuncJob{
+				Job: func(ctx context.Context, s *State) error { return nil },
+				Desc: func(d *Description) {
+					d.Append("custom")
+				},
+			},
+			want: " 1: custom\n",
+		},
+		{
+			name: "script",
+			job:  Script(Exec("echo", "ok")),
+			want: " 1: (\n 2:   echo ok\n 3: )\n",
+		},
+		{
+			name: "func-chdir",
+			job:  Chdir("otherdir"),
+			want: " 1: cd otherdir\n",
+		},
+		{
+			name: "func-setenv",
+			job:  SetEnv("key", "value"),
+			want: ` 1: export key="value"` + "\n",
+		},
+		{
+			name: "func-setenvfromjob",
+			job:  SetEnvFromJob("key", Exec("echo", "ok")),
+			want: " 1: export key=$(echo ok)\n",
 		},
 	}
 
@@ -186,8 +311,58 @@ func TestRun(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:    "system-error",
-			job:     System("exit 1"),
+			name: "func-custom",
+			job: &FuncJob{
+				Job: func(ctx context.Context, s *State) error {
+					s.Stdout.Write([]byte("output"))
+					return nil
+				},
+				Desc: func(d *Description) {},
+			},
+			want: "output",
+		},
+		{
+			name: "script",
+			job:  Script(Exec("echo", "ok")),
+			want: "ok\n",
+		},
+		{
+			name:    "script-error",
+			job:     Script(System("exit 1")),
+			wantErr: true,
+		},
+		{
+			name:    "script-deep-error",
+			job:     Script(Script(System("exit 1"))),
+			wantErr: true,
+		},
+		{
+			name:    "func-chdir",
+			job:     Chdir("otherdir"),
+			wantDir: "otherdir",
+		},
+		{
+			name:    "func-setenv",
+			job:     SetEnv("key", "value"),
+			wantEnv: "value",
+		},
+		{
+			name: "func-setenv-overwrite",
+			job: Func("reset", func(ctx context.Context, s *State) error {
+				s.SetEnv("key", "original")
+				s.SetEnv("key", "final")
+				return nil
+			}),
+			wantEnv: "final",
+		},
+		{
+			name:    "func-setenvfromjob",
+			job:     SetEnvFromJob("key", Exec("echo", "value")),
+			wantEnv: "value",
+		},
+		{
+			name:    "func-setenvfromjob-error",
+			job:     SetEnvFromJob("key", System("exit 1")),
 			wantErr: true,
 		},
 	}
@@ -239,4 +414,80 @@ func ExampleSystem() {
 		panic(err)
 	}
 	// Output: a b
+}
+
+func ExampleFuncJob_Run() {
+	f := Func("example", func(ctx context.Context, s *State) error {
+		b, err := ioutil.ReadAll(s.Stdin)
+		if err != nil {
+			return err
+		}
+		_, err = s.Stdout.Write([]byte(base64.URLEncoding.EncodeToString(b)))
+		return err
+	})
+	s := &State{
+		Stdin:  bytes.NewBuffer([]byte(`{"key":"value"}\n`)),
+		Stdout: os.Stdout,
+	}
+	err := f.Run(context.Background(), s)
+	if err != nil {
+		panic(err)
+	}
+	// Output: eyJrZXkiOiJ2YWx1ZSJ9XG4=
+}
+
+func ExampleScriptJob_Run() {
+	sc := Script(
+		SetEnv("FOO", "BAR"),
+		Exec("env"),
+	)
+	s := &State{
+		Stdout: os.Stdout,
+	}
+	err := sc.Run(context.Background(), s)
+	if err != nil {
+		panic(err)
+	}
+	// Output: FOO=BAR
+}
+
+func ExampleScriptJob_Describe() {
+	sc := Script(
+		SetEnv("FOO", "BAR"),
+		Exec("env"),
+	)
+	d := &Description{}
+	sc.Describe(d)
+	fmt.Println("\n" + d.String())
+	// Output:
+	//  1: (
+	//  2:   export FOO="BAR"
+	//  3:   env
+	//  4: )
+}
+
+func Example() {
+	sc := Script(
+		// Set environment in Script State.
+		SetEnv("KEY", "ORIGINAL"),
+		Script(
+			// Overwrite environment in sub-Script.
+			SetEnv("KEY", "SUBSCRIPT"),
+			Exec("env"),
+		),
+		// Original Script State environment was not modified by sub-Script.
+		Exec("env"),
+		// Overwrite environment using command output.
+		SetEnvFromJob("KEY", System("basename $( pwd )")),
+		Exec("env"),
+	)
+	s := New()
+	s.Env = nil // Clear state environment for example.
+	err := sc.Run(context.Background(), s)
+	if err != nil {
+		panic(err)
+	}
+	// Output: KEY=SUBSCRIPT
+	// KEY=ORIGINAL
+	// KEY=shx
 }


### PR DESCRIPTION
This change continues the addition of the `shx` package started in https://github.com/m-lab/go/pull/131, meant to replace the  `m-lab/pipe` package with better implementations and extensibility.

This change adds two types, `FuncJob` and `ScriptJob`. `FuncJob` is used to create a small set of helper functions: `Chdir`, `SetEnv`, `SetEnvFromJob`. `ScriptJob` is used to compose and execute a sequence of Jobs of any type. New unit tests and examples illustrate usage.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/go/132)
<!-- Reviewable:end -->
