### PR TITLE
Replace defer w.Close() with explicit error checking

### DIFF
--- a/cloudtest/gcsfake/gcsfake_test.go
+++ b/cloudtest/gcsfake/gcsfake_test.go
@@ -196,6 +196,11 @@ func Test_fakeWriter_Close(t *testing.T) {
 		t.Errorf("Close() returned error: %v", err)
 	}
 
+	w.closeMustFail = true
+	if err := w.Close(); err == nil {
+		t.Errorf("Close() did not return an error")
+	}
+
 }
 
 func Test_fakeReader_Read(t *testing.T) {

--- a/uploader/uploader.go
+++ b/uploader/uploader.go
@@ -26,9 +26,15 @@ func New(client stiface.Client, bucket string) *Uploader {
 func (u *Uploader) Upload(ctx context.Context, path string, content []byte) (stiface.ObjectHandle, error) {
 	obj := u.bucket.Object(path)
 	w := obj.NewWriter(ctx)
-	defer w.Close()
 
 	_, err := io.Copy(w, bytes.NewBuffer(content))
+	if err != nil {
+		return nil, err
+	}
+
+	// Avoid using defer w.Close() here as it would hide errors occurring
+	// while closing the writer, such as permission errors.
+	err = w.Close()
 	if err != nil {
 		return nil, err
 	}

--- a/uploader/uploader_test.go
+++ b/uploader/uploader_test.go
@@ -24,8 +24,11 @@ func TestUploader_Upload(t *testing.T) {
 	client := &gcsfake.GCSClient{}
 	failingBucket := gcsfake.NewBucketHandle()
 	failingBucket.WritesMustFail = true
+	failingCloseBucket := gcsfake.NewBucketHandle()
+	failingCloseBucket.ClosesMustFail = true
 	client.AddTestBucket("test_bucket", gcsfake.NewBucketHandle())
 	client.AddTestBucket("failing_bucket", failingBucket)
+	client.AddTestBucket("failing_close_bucket", failingCloseBucket)
 	type args struct {
 		ctx     context.Context
 		path    string
@@ -55,6 +58,17 @@ func TestUploader_Upload(t *testing.T) {
 			args: args{
 				ctx:     context.Background(),
 				content: []byte("failing write"),
+				path:    "this/is/a/test",
+			},
+			wantErr: true,
+		},
+		{
+			name:   "close-fails",
+			client: client,
+			bucket: "failing_close_bucket",
+			args: args{
+				ctx:     context.Background(),
+				content: []byte("failing close"),
 				path:    "this/is/a/test",
 			},
 			wantErr: true,


### PR DESCRIPTION
This PR replaces a `defer w.Close()` adding explicit error checking.

The documentation of Close() states that an object becomes available on GCS only after Close() has been successfully called.
Particularly, permission errors are only reported when closing the writer.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/go/135)
<!-- Reviewable:end -->
