### PR TITLE
Add and retract new "latest" version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,10 @@
 module github.com/m-lab/go
 
-go 1.13
+go 1.16
 
 // These v1 versions were published incorrectly. Retracting to prevent go mod
 // from automatically selecting them.
-retract [v1.0.0, v1.4.0]
+retract [v1.0.0, v1.4.1]
 
 require (
 	cloud.google.com/go/bigquery v1.6.0


### PR DESCRIPTION
This change updates the go.mod `retract` directive in order to exclude all v1.* series AND have the retract directive be in the github.com/m-lab/go@latest version.

This follows from the following reading of the retract documentation from https://golang.org/ref/mod#go-mod-file-retract :

>  To retract a version, a module author should add a retract directive to go.mod, then publish a new version containing that directive. The new version must be higher than other release or pre-release versions; that is, the @latest version query should resolve to the new version before retractions are considered.

After merging this change, we should tag v1.4.1 so that it is the latest version. Because v1.4.1 is retract'ed go should automatically find the v0.1.45 for new users.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/go/139)
<!-- Reviewable:end -->
