### PR TITLE
Strip whitespace from file content

### DIFF
--- a/flagx/keyvalue.go
+++ b/flagx/keyvalue.go
@@ -39,7 +39,7 @@ func (kv *KeyValue) Set(kvs string) error {
 				return err
 			}
 			kv.pairs[fields[0]] = kvsource{
-				value: string(b),
+				value: strings.TrimSpace(string(b)),
 				fname: fname,
 			}
 		} else {

--- a/flagx/keyvalue_test.go
+++ b/flagx/keyvalue_test.go
@@ -81,6 +81,14 @@ func TestKeyValue(t *testing.T) {
 			},
 		},
 		{
+			name: "success-strip-whitespace-newlines",
+			kvs:  "a=@" + f,
+			file: "\t d    \n\n ",
+			want: map[string]string{
+				"a": "d",
+			},
+		},
+		{
 			name:    "error-bad-key-value",
 			kvs:     "a=b,c",
 			wantErr: true,


### PR DESCRIPTION
The new functionality added in https://github.com/m-lab/go/pull/142 to read values from named files, failed to strip extra whitespace from the file content. This change strips extra whitespace to prevent strange values.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/go/143)
<!-- Reviewable:end -->
