### PR TITLE
Add common time formats not found in the Go time system package

### DIFF
--- a/timex/timex.go
+++ b/timex/timex.go
@@ -3,7 +3,7 @@ package timex
 
 // Common time formats not otherwise provided by the standard Go time package.
 const (
-	YYYYMMDD      = "20060102"
-	YYYYMMDDdash  = "2006-01-02"
-	YYYYMMDDslash = "2006/01/02"
+	YYYYMMDD          = "20060102"
+	YYYYMMDDWithDash  = "2006-01-02"
+	YYYYMMDDWithSlash = "2006/01/02"
 )

--- a/timex/timex.go
+++ b/timex/timex.go
@@ -1,0 +1,9 @@
+// Package timex provides extensions to Go's time package.
+package timex
+
+// Common time formats not otherwise provided by the standard Go time package.
+const (
+	YYYYMMDD      = "20060102"
+	YYYYMMDDdash  = "2006-01-02"
+	YYYYMMDDslash = "2006/01/02"
+)

--- a/timex/timex_test.go
+++ b/timex/timex_test.go
@@ -1,0 +1,45 @@
+// Package timex provides extensions to Go's time package.
+package timex_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/m-lab/go/timex"
+)
+
+func TestRun(t *testing.T) {
+	tests := []struct {
+		name   string
+		format string
+		input  time.Time
+		want   string
+	}{
+		{
+			name:   "YYYYMMDD",
+			format: timex.YYYYMMDD,
+			input:  time.Date(2019, time.April, 03, 0, 0, 0, 0, time.UTC),
+			want:   "20190403",
+		},
+		{
+			name:   "YYYYMMDDslash",
+			format: timex.YYYYMMDDslash,
+			input:  time.Date(2019, time.April, 03, 0, 0, 0, 0, time.UTC),
+			want:   "2019/04/03",
+		},
+		{
+			name:   "YYYYMMDDdash",
+			format: timex.YYYYMMDDdash,
+			input:  time.Date(2019, time.April, 03, 0, 0, 0, 0, time.UTC),
+			want:   "2019-04-03",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.input.Format(tt.format)
+			if tt.want != got {
+				t.Errorf("timex.%s produced wrong format; got %q, want %q", tt.name, got, tt.want)
+			}
+		})
+	}
+}

--- a/timex/timex_test.go
+++ b/timex/timex_test.go
@@ -22,14 +22,14 @@ func TestRun(t *testing.T) {
 			want:   "20190403",
 		},
 		{
-			name:   "YYYYMMDDslash",
-			format: timex.YYYYMMDDslash,
+			name:   "YYYYMMDDWithSlash",
+			format: timex.YYYYMMDDWithSlash,
 			input:  time.Date(2019, time.April, 03, 0, 0, 0, 0, time.UTC),
 			want:   "2019/04/03",
 		},
 		{
-			name:   "YYYYMMDDdash",
-			format: timex.YYYYMMDDdash,
+			name:   "YYYYMMDDWithDash",
+			format: timex.YYYYMMDDWithDash,
 			input:  time.Date(2019, time.April, 03, 0, 0, 0, 0, time.UTC),
 			want:   "2019-04-03",
 		},


### PR DESCRIPTION
This change adds a new package for extensions to Go's `time` package. In particular, we regularly want to use time formats not defined by the `time` package. Namely, `YYYYMMDD`, `YYYY/MM/DD`, and `YYYY-MM-DD` are common throughout M-Lab's data pipeline and other tools.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/go/149)
<!-- Reviewable:end -->
