### PR TITLE
Add new mathx package

### DIFF
--- a/mathx/compare.go
+++ b/mathx/compare.go
@@ -1,0 +1,9 @@
+package mathx
+
+// Min returns the minimum of two ints.
+func Min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/mathx/compare_test.go
+++ b/mathx/compare_test.go
@@ -1,0 +1,52 @@
+package mathx
+
+import "testing"
+
+func TestMin(t *testing.T) {
+	tests := []struct {
+		name     string
+		a        int
+		b        int
+		expected int
+	}{
+		{
+			name:     "pos-pos",
+			a:        2,
+			b:        3,
+			expected: 2,
+		},
+		{
+			name:     "neg-neg",
+			a:        -2,
+			b:        -3,
+			expected: -3,
+		},
+		{
+			name:     "pos-neg",
+			a:        2,
+			b:        -3,
+			expected: -3,
+		},
+		{
+			name:     "same",
+			a:        2,
+			b:        2,
+			expected: 2,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Min(tt.a, tt.b)
+
+			if got != tt.expected {
+				t.Errorf("Min() = %d, want %d", got, tt.expected)
+			}
+
+			got = Min(tt.b, tt.a)
+
+			if got != tt.expected {
+				t.Errorf("Min() = %d, want %d", got, tt.expected)
+			}
+		})
+	}
+}

--- a/mathx/haversine.go
+++ b/mathx/haversine.go
@@ -8,12 +8,20 @@ const earthRadius = 6371
 
 // GetHaversineDistance finds the distance (in km) between two latitude/longitude
 // pairs using the Haversine formula.
+// For more details, see http://en.wikipedia.org/wiki/Haversine_formula.
 func GetHaversineDistance(lat1, lon1, lat2, lon2 float64) float64 {
-	dlat := degreesToRadian(lat2 - lat1)
-	dlon := degreesToRadian(lon2 - lon1)
+	dlat1 := degreesToRadian(lat1)
+	dlon1 := degreesToRadian(lon1)
+	dlat2 := degreesToRadian(lat2)
+	dlon2 := degreesToRadian(lon2)
 
-	a := math.Sin(dlat/2)*math.Sin(dlat/2) + math.Cos(degreesToRadian(lat1))*
-		math.Cos(degreesToRadian(lat2))*math.Sin(dlon/2)*math.Sin(dlon/2)
+	diffLat := dlat2 - dlat1
+	diffLon := dlon2 - dlon1
+	sinDiffLat := math.Sin(diffLat / 2)
+	sinDiffLon := math.Sin(diffLon / 2)
+
+	a := sinDiffLat*sinDiffLat + math.Cos(dlat1)*
+		math.Cos(dlat2)*sinDiffLon*sinDiffLon
 	c := 2 * math.Atan2(math.Sqrt(a), math.Sqrt(1-a))
 	d := earthRadius * c
 

--- a/mathx/haversine.go
+++ b/mathx/haversine.go
@@ -1,0 +1,25 @@
+package mathx
+
+import (
+	"math"
+)
+
+const earthRadius = 6371
+
+// GetHaversineDistance finds the distance (in km) between two latitude/longitude
+// pairs using the Haversine formula.
+func GetHaversineDistance(lat1 float64, lon1 float64, lat2 float64, lon2 float64) float64 {
+	dlat := degreesToRadian(lat2 - lat1)
+	dlon := degreesToRadian(lon2 - lon1)
+
+	a := math.Sin(dlat/2)*math.Sin(dlat/2) + math.Cos(degreesToRadian(lat1))*
+		math.Cos(degreesToRadian(lat2))*math.Sin(dlon/2)*math.Sin(dlon/2)
+	c := 2 * math.Atan2(math.Sqrt(a), math.Sqrt(1-a))
+	d := earthRadius * c
+
+	return d
+}
+
+func degreesToRadian(d float64) float64 {
+	return d * math.Pi / 180
+}

--- a/mathx/haversine.go
+++ b/mathx/haversine.go
@@ -8,7 +8,7 @@ const earthRadius = 6371
 
 // GetHaversineDistance finds the distance (in km) between two latitude/longitude
 // pairs using the Haversine formula.
-func GetHaversineDistance(lat1 float64, lon1 float64, lat2 float64, lon2 float64) float64 {
+func GetHaversineDistance(lat1, lon1, lat2, lon2 float64) float64 {
 	dlat := degreesToRadian(lat2 - lat1)
 	dlon := degreesToRadian(lon2 - lon1)
 

--- a/mathx/haversine.go
+++ b/mathx/haversine.go
@@ -4,7 +4,7 @@ import (
 	"math"
 )
 
-const earthRadius = 6371
+const earthRadiusKm = 6371
 
 // GetHaversineDistance finds the distance (in km) between two latitude/longitude
 // pairs using the Haversine formula.
@@ -23,7 +23,7 @@ func GetHaversineDistance(lat1, lon1, lat2, lon2 float64) float64 {
 	a := sinDiffLat*sinDiffLat + math.Cos(dlat1)*
 		math.Cos(dlat2)*sinDiffLon*sinDiffLon
 	c := 2 * math.Atan2(math.Sqrt(a), math.Sqrt(1-a))
-	d := earthRadius * c
+	d := earthRadiusKm * c
 
 	return d
 }

--- a/mathx/haversine_test.go
+++ b/mathx/haversine_test.go
@@ -1,0 +1,62 @@
+package mathx
+
+import (
+	"math"
+	"testing"
+)
+
+func TestGetHaversineDistance(t *testing.T) {
+	tests := []struct {
+		name     string
+		lat1     float64
+		lon1     float64
+		lat2     float64
+		lon2     float64
+		expected float64
+	}{
+		{
+			name:     "US-UK",
+			lat1:     37.09024,
+			lon1:     -95.712891,
+			lat2:     55.378051,
+			lon2:     -3.435973,
+			expected: 6830.40,
+		},
+		{
+			name:     "US-US",
+			lat1:     37.09024,
+			lon1:     -95.712891,
+			lat2:     37.09024,
+			lon2:     -95.712891,
+			expected: 0,
+		},
+		{
+			name:     "0-UK",
+			lat1:     0,
+			lon1:     0,
+			lat2:     55.378051,
+			lon2:     -3.435973,
+			expected: 6165.67,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetHaversineDistance(tt.lat1, tt.lon1, tt.lat2, tt.lon2)
+
+			if !compareFloats(got, tt.expected) {
+				t.Errorf("GetHaversineDistance() = %f, want %f", got, tt.expected)
+			}
+
+			got = GetHaversineDistance(tt.lat2, tt.lon2, tt.lat1, tt.lon1)
+
+			if !compareFloats(got, tt.expected) {
+				t.Errorf("GetHaversineDistance() = %f, want %f", got, tt.expected)
+			}
+		})
+	}
+}
+
+func compareFloats(f1 float64, f2 float64) bool {
+	diff := math.Abs(f1 - f2)
+	return diff < 0.01
+}

--- a/mathx/rand.go
+++ b/mathx/rand.go
@@ -1,0 +1,40 @@
+package mathx
+
+import (
+	"math"
+	"math/rand"
+)
+
+// Random is a source of random values.
+type Random struct {
+	src *rand.Rand
+}
+
+// NewRandom returns a new Random that uses the provided seed to generate
+// random values.
+func NewRandom(seed int64) Random {
+	src := rand.New(rand.NewSource(seed))
+	return Random{src: src}
+}
+
+// GetRandomInt returns a non-negative pseudo-random number in the interval [0, max).
+// It returns 0 if n <= 0.
+func (r *Random) GetRandomInt(max int) int {
+	if max <= 0 {
+		return 0
+	}
+	return r.src.Intn(max)
+}
+
+// GetExpDistributedInt returns a exponentially distributed number in the interval
+// [0, max), rounded to the nearest int. Callers can adjust the rate of the
+// function through the rate parameter.
+func (r *Random) GetExpDistributedInt(max int, rate float64) int {
+	if max <= 0 {
+		return 0
+	}
+
+	f := r.src.ExpFloat64() / rate
+	index := int(math.Round(f))
+	return index % max
+}

--- a/mathx/rand.go
+++ b/mathx/rand.go
@@ -27,15 +27,10 @@ func (r *Random) GetRandomInt(max int) int {
 }
 
 // GetExpDistributedInt returns a exponentially distributed number in the interval
-// [0, max), rounded to the nearest int. Callers can adjust the rate of the
+// [0, +math.MaxFloat64), rounded to the nearest int. Callers can adjust the rate of the
 // function through the rate parameter.
-// It returns 0 if max <= 0.
-func (r *Random) GetExpDistributedInt(max int, rate float64) int {
-	if max <= 0 {
-		return 0
-	}
-
+func (r *Random) GetExpDistributedInt(rate float64) int {
 	f := r.src.ExpFloat64() / rate
 	index := int(math.Round(f))
-	return index % max
+	return index
 }

--- a/mathx/rand.go
+++ b/mathx/rand.go
@@ -18,7 +18,7 @@ func NewRandom(seed int64) Random {
 }
 
 // GetRandomInt returns a non-negative pseudo-random number in the interval [0, max).
-// It returns 0 if n <= 0.
+// It returns 0 if max <= 0.
 func (r *Random) GetRandomInt(max int) int {
 	if max <= 0 {
 		return 0
@@ -29,6 +29,7 @@ func (r *Random) GetRandomInt(max int) int {
 // GetExpDistributedInt returns a exponentially distributed number in the interval
 // [0, max), rounded to the nearest int. Callers can adjust the rate of the
 // function through the rate parameter.
+// It returns 0 if max <= 0.
 func (r *Random) GetExpDistributedInt(max int, rate float64) int {
 	if max <= 0 {
 		return 0

--- a/mathx/rand_test.go
+++ b/mathx/rand_test.go
@@ -64,23 +64,16 @@ func TestRandom_GetExpDistributedInt(t *testing.T) {
 			expected2: 0,
 		},
 		{
-			name:      "rate-2",
+			name:      "rate-0.1",
 			max:       10,
-			rate:      2,
-			expected1: 0,
-			expected2: 0,
+			rate:      0.1,
+			expected1: 5,
+			expected2: 2,
 		},
 		{
-			name:      "zero",
-			max:       0,
-			rate:      1,
-			expected1: 0,
-			expected2: 0,
-		},
-		{
-			name:      "negative",
-			max:       -10,
-			rate:      1,
+			name:      "rate-5",
+			max:       10,
+			rate:      5,
 			expected1: 0,
 			expected2: 0,
 		},
@@ -88,13 +81,13 @@ func TestRandom_GetExpDistributedInt(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := NewRandom(seed)
-			got := r.GetExpDistributedInt(tt.max, tt.rate)
+			got := r.GetExpDistributedInt(tt.rate)
 
 			if got != tt.expected1 {
 				t.Errorf("GetExpDistributedInt() = %d, want %d", got, tt.expected1)
 			}
 
-			got = r.GetExpDistributedInt(tt.max, tt.rate)
+			got = r.GetExpDistributedInt(tt.rate)
 
 			if got != tt.expected2 {
 				t.Errorf("GetExpDistributedInt() = %d, want %d", got, tt.expected2)

--- a/mathx/rand_test.go
+++ b/mathx/rand_test.go
@@ -51,28 +51,24 @@ func TestRandom_GetRandomInt(t *testing.T) {
 func TestRandom_GetExpDistributedInt(t *testing.T) {
 	tests := []struct {
 		name      string
-		max       int
 		rate      float64
 		expected1 int
 		expected2 int
 	}{
 		{
 			name:      "rate-1",
-			max:       10,
 			rate:      1,
 			expected1: 1,
 			expected2: 0,
 		},
 		{
 			name:      "rate-0.1",
-			max:       10,
 			rate:      0.1,
 			expected1: 5,
 			expected2: 2,
 		},
 		{
 			name:      "rate-5",
-			max:       10,
 			rate:      5,
 			expected1: 0,
 			expected2: 0,

--- a/mathx/rand_test.go
+++ b/mathx/rand_test.go
@@ -1,0 +1,104 @@
+package mathx
+
+import "testing"
+
+const seed = 1658340109320624211
+
+func TestRandom_GetRandomInt(t *testing.T) {
+	tests := []struct {
+		name      string
+		max       int
+		expected1 int
+		expected2 int
+	}{
+		{
+			name:      "random",
+			max:       10,
+			expected1: 6,
+			expected2: 8,
+		},
+		{
+			name:      "zero",
+			max:       0,
+			expected1: 0,
+			expected2: 0,
+		},
+		{
+			name:      "negative",
+			max:       -10,
+			expected1: 0,
+			expected2: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := NewRandom(seed)
+			got := r.GetRandomInt(tt.max)
+
+			if got != tt.expected1 {
+				t.Errorf("GetRandomInt() = %d, want %d", got, tt.expected1)
+			}
+
+			got = r.GetRandomInt(tt.max)
+
+			if got != tt.expected2 {
+				t.Errorf("GetRandomInt() = %d, want %d", got, tt.expected2)
+			}
+		})
+	}
+}
+
+func TestRandom_GetExpDistributedInt(t *testing.T) {
+	tests := []struct {
+		name      string
+		max       int
+		rate      float64
+		expected1 int
+		expected2 int
+	}{
+		{
+			name:      "rate-1",
+			max:       10,
+			rate:      1,
+			expected1: 1,
+			expected2: 0,
+		},
+		{
+			name:      "rate-2",
+			max:       10,
+			rate:      2,
+			expected1: 0,
+			expected2: 0,
+		},
+		{
+			name:      "zero",
+			max:       0,
+			rate:      1,
+			expected1: 0,
+			expected2: 0,
+		},
+		{
+			name:      "negative",
+			max:       -10,
+			rate:      1,
+			expected1: 0,
+			expected2: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := NewRandom(seed)
+			got := r.GetExpDistributedInt(tt.max, tt.rate)
+
+			if got != tt.expected1 {
+				t.Errorf("GetExpDistributedInt() = %d, want %d", got, tt.expected1)
+			}
+
+			got = r.GetExpDistributedInt(tt.max, tt.rate)
+
+			if got != tt.expected2 {
+				t.Errorf("GetExpDistributedInt() = %d, want %d", got, tt.expected2)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds math functions to a new `mathx` package.

I thought it was very [unexpected](https://unexpected-go.com/theres-no-min-function.html) that the `math` package does not have a "Min" comparison function for `int`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/go/150)
<!-- Reviewable:end -->
