### PR TITLE
Export Random.Src in the mathx package

### DIFF
--- a/mathx/rand.go
+++ b/mathx/rand.go
@@ -7,14 +7,14 @@ import (
 
 // Random is a source of random values.
 type Random struct {
-	src *rand.Rand
+	Src *rand.Rand // Pseudo-random source seeded with a given value.
 }
 
 // NewRandom returns a new Random that uses the provided seed to generate
 // random values.
 func NewRandom(seed int64) Random {
 	src := rand.New(rand.NewSource(seed))
-	return Random{src: src}
+	return Random{Src: src}
 }
 
 // GetRandomInt returns a non-negative pseudo-random number in the interval [0, max).
@@ -23,14 +23,14 @@ func (r *Random) GetRandomInt(max int) int {
 	if max <= 0 {
 		return 0
 	}
-	return r.src.Intn(max)
+	return r.Src.Intn(max)
 }
 
 // GetExpDistributedInt returns a exponentially distributed number in the interval
 // [0, +math.MaxFloat64), rounded to the nearest int. Callers can adjust the rate of the
 // function through the rate parameter.
 func (r *Random) GetExpDistributedInt(rate float64) int {
-	f := r.src.ExpFloat64() / rate
+	f := r.Src.ExpFloat64() / rate
 	index := int(math.Round(f))
 	return index
 }


### PR DESCRIPTION
This PR exports the `Src` field in the `Random` struct so the core `rand` functions can be used by other packages.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/go/152)
<!-- Reviewable:end -->
