### PR TITLE
Add IP Anonymization Contains method

### DIFF
--- a/anonymize/ip.go
+++ b/anonymize/ip.go
@@ -176,7 +176,7 @@ func (netblockAnonymizer) IP(ip net.IP) {
 	return
 }
 
-// Contains determines whether the dst IP (treated as an anonymized netblock), contains the given dst address.
+// Contains determines whether the dst IP (as if netblock anonymized), contains the given dst address.
 func (n netblockAnonymizer) Contains(dst, ip net.IP) bool {
 	if dst == nil || ip == nil {
 		return false

--- a/anonymize/ip_test.go
+++ b/anonymize/ip_test.go
@@ -175,17 +175,24 @@ func TestAnonymizerContains(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "error-invalid-ip-byte-array",
+			name: "error-invalid-byte-array-1-byte-ip",
+			n:    anonymize.New(anonymize.Netblock),
+			dst:  []byte{'0'},
+			ip:   net.ParseIP("127.0.0.1"),
+			want: false,
+		},
+		{
+			name: "error-invalid-byte-array-5-byte-ip",
 			n:    anonymize.New(anonymize.Netblock),
 			dst:  append(net.ParseIP("127.0.0.1"), '0'),
 			ip:   net.ParseIP("127.0.0.1"),
 			want: false,
 		},
 		{
-			name: "error-invalid-ip-byte-array",
+			name: "error-invalid-byte-array-17-byte-ip",
 			n:    anonymize.New(anonymize.Netblock),
-			dst:  append(net.ParseIP("127.0.0.1"), '0'),
-			ip:   net.ParseIP("127.0.0.1"),
+			dst:  append(net.ParseIP("fd12:3456:789a:1::1"), '0'),
+			ip:   net.ParseIP("2::1"),
 			want: false,
 		},
 	}

--- a/anonymize/ip_test.go
+++ b/anonymize/ip_test.go
@@ -101,7 +101,7 @@ func Example() {
 	log.Println(ip) // Should be "10.10.4.0" if the --anonymize.ip=netblock command-line flag was passed.
 }
 
-func Test_netblockAnonymizer_Contains(t *testing.T) {
+func TestAnonymizerContains(t *testing.T) {
 	anonymize.IgnoredIPs = []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("1::2")}
 	tests := []struct {
 		name string
@@ -126,14 +126,14 @@ func Test_netblockAnonymizer_Contains(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "success-nullanonymizer-ipv4-no-match",
+			name: "nullanonymizer-ipv4-no-match",
 			n:    anonymize.New(anonymize.None),
 			dst:  net.ParseIP("192.168.0.1"),
 			ip:   net.ParseIP("192.168.0.2"),
 			want: false,
 		},
 		{
-			name: "success-nullanonymizer-ipv4-match",
+			name: "nullanonymizer-ipv4-match",
 			n:    anonymize.New(anonymize.None),
 			dst:  net.ParseIP("192.168.0.2"),
 			ip:   net.ParseIP("192.168.0.2"),


### PR DESCRIPTION
This change adds a new method to the `anonymize.IPAnonymizer` interface:
* `Contains(dst, ip net.IP) bool`

This new method allows a caller to assess whether a given `dst` IP "contains" the second given `ip`, if `dst` were treated as a netblock based on the configured anonymization method.

For example:
* Does "192.168.0.1/24" contain "192.168.0.3" ? Yes
* Does "2001:668:1f:22::73/64" contain "2001:1900:2100:2d::114" ? No

This functionality is helpful for applying netblock anonymization to hop IPs within a client subnet, even if they are not the same as the client IP.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/go/153)
<!-- Reviewable:end -->
