### PR TITLE
Apply /48 mask for ipv6 netblock anonymization

### DIFF
--- a/anonymize/ip.go
+++ b/anonymize/ip.go
@@ -166,8 +166,8 @@ func (netblockAnonymizer) IP(ip net.IP) {
 		return
 	}
 	if ip.To16() != nil {
-		// Anonymize IPv6 addresses to the containing /64
-		for i := 8; i < 16; i++ {
+		// Truncate IPv6 addresses to the containing /48
+		for i := 6; i < 16; i++ {
 			ip[i] = 0
 		}
 		return
@@ -196,7 +196,7 @@ func (n netblockAnonymizer) Contains(dst, ip net.IP) bool {
 	if dst.To16() != nil {
 		nn := &net.IPNet{
 			IP:   dst,
-			Mask: net.CIDRMask(64, 128),
+			Mask: net.CIDRMask(48, 128),
 		}
 		return nn.Contains(ip)
 	}

--- a/anonymize/ip_test.go
+++ b/anonymize/ip_test.go
@@ -58,8 +58,8 @@ func TestNetblockAnon(t *testing.T) {
 		{"1:0::2", "1::2"},         // IgnoredIPs should be ignored.
 		{"10.1.2.3", "10.1.2.0"},
 		{"255.255.255.255", "255.255.255.0"},
-		{"0:1:2:3:4:5:6:7", "0:1:2:3::"},
-		{"aaaa:aaab:aaac:aaad:aaae:aaaf:aaa1:aaa1", "aaaa:aaab:aaac:aaad::"},
+		{"0:1:2:3:4:5:6:7", "0:1:2::"},
+		{"aaaa:aaab:aaac:aaad:aaae:aaaf:aaa1:aaa1", "aaaa:aaab:aaac::"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.ip, func(t *testing.T) {


### PR DESCRIPTION
This change updates the behavior of "netblock" anonymization for IPv6 addresses. Previously, netblock anonymization would mask the lower 64 bits (i.e. /64), now the lower 80 bits are masked (i.e. /48).

This change is to be consistent with current best practices for user privacy [1] and the fact that /48 is the recommended minimum prefix size for globally routed prefixes in BGP and that some ISPs supporting IPv6 assign /64 blocks for a single subnet (i.e. a single home) [2].

[1]: https://support.google.com/analytics/answer/2763052?hl=en
[2]: https://blog.apnic.net/2020/06/01/why-is-a-48-the-recommended-minimum-prefix-size-for-routing/

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/go/154)
<!-- Reviewable:end -->
