### PR TITLE
Allow for a 4 char suffix on the end of hostnames

### DIFF
--- a/host/host.go
+++ b/host/host.go
@@ -34,6 +34,7 @@ func Parse(name string) (Name, error) {
 	//   ndt.iupui.mlab1.lga01.measurement-lab.org  - 6
 	// v2
 	//   mlab1-lga01.mlab-oti.measurement-lab.org - 4
+	//   mlab1-lga01.mlab-oti.measurement-lab.org-d9h6 - 4  (A MIG instance with a random suffix)
 	//   ndt-iupui-mlab1-lga01.mlab-oti.measurement-lab.org - 4
 	//   ndt-mlab1-lga01.mlab-oti.measurement-lab.org - 4
 

--- a/host/host.go
+++ b/host/host.go
@@ -15,6 +15,7 @@ type Name struct {
 	Site    string
 	Project string
 	Domain  string
+	Suffix  string
 	Version string
 }
 
@@ -24,7 +25,7 @@ func Parse(name string) (Name, error) {
 	var parts Name
 
 	reV1 := regexp.MustCompile(`(?:[a-z-.]+)?(mlab[1-4]d?)[-.]([a-z]{3}[0-9tc]{2})\.(measurement-lab.org)$`)
-	reV2 := regexp.MustCompile(`(?:[a-z-.]+)?(mlab[1-4]d?)-([a-z]{3}[0-9tc]{2})\.(.*?)\.(measurement-lab.org)$`)
+	reV2 := regexp.MustCompile(`(?:[a-z-.]+)?(mlab[1-4]d?)-([a-z]{3}[0-9tc]{2})\.(.*?)\.(measurement-lab.org)-?([a-z0-9]{4})?$`)
 
 	// Example hostnames with field counts when split by '.':
 	// v1
@@ -45,7 +46,7 @@ func Parse(name string) (Name, error) {
 	// be longer than a machine name e.g. "mlab1".
 	if len(fields) == 4 && len(fields[0]) > 6 {
 		mV2 := reV2.FindAllStringSubmatch(name, -1)
-		if len(mV2) != 1 || len(mV2[0]) != 5 {
+		if len(mV2) != 1 || len(mV2[0]) != 6 {
 			return parts, fmt.Errorf("Invalid v2 hostname: %s", name)
 		}
 		parts = Name{
@@ -53,6 +54,7 @@ func Parse(name string) (Name, error) {
 			Site:    mV2[0][2],
 			Project: mV2[0][3],
 			Domain:  mV2[0][4],
+			Suffix:  mV2[0][5],
 			Version: "v2",
 		}
 	} else {

--- a/host/host_test.go
+++ b/host/host_test.go
@@ -37,6 +37,18 @@ func TestName(t *testing.T) {
 			},
 		},
 		{
+			name:     "valid-v2-with-suffix",
+			hostname: "mlab1-lol01.mlab-oti.measurement-lab.org-a9b8",
+			want: Name{
+				Machine: "mlab1",
+				Site:    "lol01",
+				Project: "mlab-oti",
+				Domain:  "measurement-lab.org",
+				Suffix:  "a9b8",
+				Version: "v2",
+			},
+		},
+		{
 			name:     "valid-v1-bmc",
 			hostname: "mlab1d.lol01.measurement-lab.org",
 			want: Name{
@@ -96,6 +108,18 @@ func TestName(t *testing.T) {
 				Site:    "lol01",
 				Project: "mlab-oti",
 				Domain:  "measurement-lab.org",
+				Version: "v2",
+			},
+		},
+		{
+			name:     "valid-v2-with-ndt-short-with-suffix",
+			hostname: "ndt-mlab1-lol01.mlab-oti.measurement-lab.org-q44c",
+			want: Name{
+				Machine: "mlab1",
+				Site:    "lol01",
+				Project: "mlab-oti",
+				Domain:  "measurement-lab.org",
+				Suffix:  "q44c",
 				Version: "v2",
 			},
 		},


### PR DESCRIPTION
As we migrate cloud deployments to use a load balancer backed by managed instance groups, we can no longer count on machine names to be predetermined. MIG instances have a "-<4 char>" suffix, and are managed by the instance group, not M-Lab. In order to support this use case, the changes in this PR allow for a suffix to be part of the hostname without failing Parse(). Callers can use the suffix, if found, or not.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/go/156)
<!-- Reviewable:end -->
