### PR TITLE
Adds funcs to return strings w/ prefixes and suffixes

### DIFF
--- a/host/host.go
+++ b/host/host.go
@@ -95,7 +95,7 @@ func (n Name) StringWithService() string {
 	if n.Service != "" {
 		return fmt.Sprintf("%s-%s-%s.%s.%s", n.Service, n.Machine, n.Site, n.Project, n.Domain)
 	} else {
-		return fmt.Sprintf("%s-%s.%s.%s", n.Machine, n.Site, n.Project, n.Domain)
+		return n.String()
 	}
 }
 
@@ -108,13 +108,5 @@ func (n Name) StringWithSuffix() string {
 // Returns an M-lab hostname with any service and suffix preserved
 // Example: ndt-mlab1-abc01.mlab-sandbox.measurement-lab.org-gz77
 func (n Name) StringAll() string {
-	var s string
-
-	if n.Service != "" {
-		s = n.Service + "-"
-	} else {
-		s = ""
-	}
-
-	return fmt.Sprintf("%s%s-%s.%s.%s%s", s, n.Machine, n.Site, n.Project, n.Domain, n.Suffix)
+	return n.StringWithService() + n.Suffix
 }

--- a/host/host.go
+++ b/host/host.go
@@ -36,7 +36,7 @@ func Parse(name string) (Name, error) {
 	// v2
 	//   mlab1-lga01.mlab-oti.measurement-lab.org - 4
 	//   mlab1-lga01.mlab-oti.measurement-lab.org-d9h6 - 4 (A MIG instance with a random suffix)
-	//   ndt-mlab1-lga01.mlab-oti.measurement-lab.org-d9h6 - 4 (A MIG instance with a prefix and random suffix)
+	//   ndt-mlab1-lga01.mlab-oti.measurement-lab.org-d9h6 - 4 (A MIG instance with a service and random suffix)
 	//   ndt-iupui-mlab1-lga01.mlab-oti.measurement-lab.org - 4
 	//   ndt-mlab1-lga01.mlab-oti.measurement-lab.org - 4
 
@@ -89,10 +89,14 @@ func (n Name) String() string {
 	}
 }
 
-// Returns an M-lab hostname with any prefix preserved
+// Returns an M-lab hostname with any service name preserved
 // Example: ndt-mlab1-abc01.mlab-sandbox.measurement-lab.org
-func (n Name) StringWithPrefix() string {
-	return fmt.Sprintf("%s-%s-%s.%s.%s", n.Service, n.Machine, n.Site, n.Project, n.Domain)
+func (n Name) StringWithService() string {
+	if n.Service != "" {
+		return fmt.Sprintf("%s-%s-%s.%s.%s", n.Service, n.Machine, n.Site, n.Project, n.Domain)
+	} else {
+		return fmt.Sprintf("%s-%s.%s.%s", n.Machine, n.Site, n.Project, n.Domain)
+	}
 }
 
 // Returns an M-lab hostname with any suffix preserved
@@ -101,8 +105,16 @@ func (n Name) StringWithSuffix() string {
 	return fmt.Sprintf("%s-%s.%s.%s%s", n.Machine, n.Site, n.Project, n.Domain, n.Suffix)
 }
 
-// Returns an M-lab hostname with any prefix and suffix preserved
+// Returns an M-lab hostname with any service and suffix preserved
 // Example: ndt-mlab1-abc01.mlab-sandbox.measurement-lab.org-gz77
 func (n Name) StringAll() string {
-	return fmt.Sprintf("%s-%s-%s.%s.%s%s", n.Service, n.Machine, n.Site, n.Project, n.Domain, n.Suffix)
+	var s string
+
+	if n.Service != "" {
+		s = n.Service + "-"
+	} else {
+		s = ""
+	}
+
+	return fmt.Sprintf("%s%s-%s.%s.%s%s", s, n.Machine, n.Site, n.Project, n.Domain, n.Suffix)
 }

--- a/host/host.go
+++ b/host/host.go
@@ -11,7 +11,7 @@ import (
 
 // Name represents an M-Lab hostname and all of its constituent parts.
 type Name struct {
-	Prefix  string
+	Service string
 	Machine string
 	Site    string
 	Project string
@@ -26,7 +26,7 @@ func Parse(name string) (Name, error) {
 	var parts Name
 
 	reV1 := regexp.MustCompile(`(?:[a-z-.]+)?(mlab[1-4]d?)[-.]([a-z]{3}[0-9tc]{2})\.(measurement-lab.org)$`)
-	reV2 := regexp.MustCompile(`([a-z-]+)?(mlab[1-4]d?)-([a-z]{3}[0-9tc]{2})\.(.*?)\.(measurement-lab.org)(-[a-z0-9]{4})?$`)
+	reV2 := regexp.MustCompile(`([a-z0-9]+)?-?(mlab[1-4]d?)-([a-z]{3}[0-9tc]{2})\.(.*?)\.(measurement-lab.org)(-[a-z0-9]{4})?$`)
 
 	// Example hostnames with field counts when split by '.':
 	// v1
@@ -53,7 +53,7 @@ func Parse(name string) (Name, error) {
 			return parts, fmt.Errorf("invalid v2 hostname: %s", name)
 		}
 		parts = Name{
-			Prefix:  mV2[0][1],
+			Service: mV2[0][1],
 			Machine: mV2[0][2],
 			Site:    mV2[0][3],
 			Project: mV2[0][4],
@@ -92,7 +92,7 @@ func (n Name) String() string {
 // Returns an M-lab hostname with any prefix preserved
 // Example: ndt-mlab1-abc01.mlab-sandbox.measurement-lab.org
 func (n Name) StringWithPrefix() string {
-	return fmt.Sprintf("%s%s-%s.%s.%s", n.Prefix, n.Machine, n.Site, n.Project, n.Domain)
+	return fmt.Sprintf("%s-%s-%s.%s.%s", n.Service, n.Machine, n.Site, n.Project, n.Domain)
 }
 
 // Returns an M-lab hostname with any suffix preserved
@@ -104,5 +104,5 @@ func (n Name) StringWithSuffix() string {
 // Returns an M-lab hostname with any prefix and suffix preserved
 // Example: ndt-mlab1-abc01.mlab-sandbox.measurement-lab.org-gz77
 func (n Name) StringAll() string {
-	return fmt.Sprintf("%s%s-%s.%s.%s%s", n.Prefix, n.Machine, n.Site, n.Project, n.Domain, n.Suffix)
+	return fmt.Sprintf("%s-%s-%s.%s.%s%s", n.Service, n.Machine, n.Site, n.Project, n.Domain, n.Suffix)
 }

--- a/host/host_test.go
+++ b/host/host_test.go
@@ -172,16 +172,130 @@ func TestName(t *testing.T) {
 func TestName_String(t *testing.T) {
 	tests := []struct {
 		name string
+		want string
 	}{
-		{name: "mlab1.foo01.measurement-lab.org"},
-		{name: "mlab1-foo01.mlab-sandbox.measurement-lab.org"},
+		{
+			name: "mlab1.foo01.measurement-lab.org",
+			want: "mlab1.foo01.measurement-lab.org",
+		},
+		{
+			name: "mlab1-foo01.mlab-sandbox.measurement-lab.org",
+			want: "mlab1-foo01.mlab-sandbox.measurement-lab.org",
+		},
+		{
+			name: "ndt-mlab1-foo01.mlab-sandbox.measurement-lab.org",
+			want: "mlab1-foo01.mlab-sandbox.measurement-lab.org",
+		},
+		{
+			name: "ndt-mlab1-foo01.mlab-sandbox.measurement-lab.org-qf8y",
+			want: "mlab1-foo01.mlab-sandbox.measurement-lab.org",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			n, err := Parse(tt.name)
 			rtx.Must(err, "Failed to parse: %s", tt.name)
-			if got := n.String(); got != tt.name {
-				t.Errorf("Name.String() = %v, want %v", got, tt.name)
+			if got := n.String(); got != tt.want {
+				t.Errorf("Name.String() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestName_StringWithService(t *testing.T) {
+	tests := []struct {
+		name string
+		want string
+	}{
+		{
+			name: "mlab1-foo01.mlab-sandbox.measurement-lab.org",
+			want: "mlab1-foo01.mlab-sandbox.measurement-lab.org",
+		},
+		{
+			name: "ndt-mlab1-foo01.mlab-sandbox.measurement-lab.org",
+			want: "ndt-mlab1-foo01.mlab-sandbox.measurement-lab.org",
+		},
+		{
+			name: "mlab1-foo01.mlab-sandbox.measurement-lab.org-qf8y",
+			want: "mlab1-foo01.mlab-sandbox.measurement-lab.org",
+		},
+		{
+			name: "ndt-mlab1-foo01.mlab-sandbox.measurement-lab.org-qf8y",
+			want: "ndt-mlab1-foo01.mlab-sandbox.measurement-lab.org",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			n, err := Parse(tt.name)
+			rtx.Must(err, "Failed to parse: %s", tt.name)
+			if got := n.StringWithService(); got != tt.want {
+				t.Errorf("Name.StringWithService() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestName_StringWithSuffix(t *testing.T) {
+	tests := []struct {
+		name string
+		want string
+	}{
+		{
+			name: "mlab1-foo01.mlab-sandbox.measurement-lab.org",
+			want: "mlab1-foo01.mlab-sandbox.measurement-lab.org",
+		},
+		{
+			name: "ndt-mlab1-foo01.mlab-sandbox.measurement-lab.org",
+			want: "mlab1-foo01.mlab-sandbox.measurement-lab.org",
+		},
+		{
+			name: "mlab1-foo01.mlab-sandbox.measurement-lab.org-qf8y",
+			want: "mlab1-foo01.mlab-sandbox.measurement-lab.org-qf8y",
+		},
+		{
+			name: "ndt-mlab1-foo01.mlab-sandbox.measurement-lab.org-qf8y",
+			want: "mlab1-foo01.mlab-sandbox.measurement-lab.org-qf8y",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			n, err := Parse(tt.name)
+			rtx.Must(err, "Failed to parse: %s", tt.name)
+			if got := n.StringWithSuffix(); got != tt.want {
+				t.Errorf("Name.StringWithSuffix() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestName_StringAll(t *testing.T) {
+	tests := []struct {
+		name string
+		want string
+	}{
+		{
+			name: "mlab1-foo01.mlab-sandbox.measurement-lab.org",
+			want: "mlab1-foo01.mlab-sandbox.measurement-lab.org",
+		},
+		{
+			name: "ndt-mlab1-foo01.mlab-sandbox.measurement-lab.org",
+			want: "ndt-mlab1-foo01.mlab-sandbox.measurement-lab.org",
+		},
+		{
+			name: "mlab1-foo01.mlab-sandbox.measurement-lab.org-qf8y",
+			want: "mlab1-foo01.mlab-sandbox.measurement-lab.org-qf8y",
+		},
+		{
+			name: "ndt-mlab1-foo01.mlab-sandbox.measurement-lab.org-qf8y",
+			want: "ndt-mlab1-foo01.mlab-sandbox.measurement-lab.org-qf8y",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			n, err := Parse(tt.name)
+			rtx.Must(err, "Failed to parse: %s", tt.name)
+			if got := n.StringAll(); got != tt.want {
+				t.Errorf("Name.StringAll() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/host/host_test.go
+++ b/host/host_test.go
@@ -49,10 +49,10 @@ func TestName(t *testing.T) {
 			},
 		},
 		{
-			name:     "valid-v2-with-prefix",
+			name:     "valid-v2-with-service",
 			hostname: "ndt-mlab1-lol01.mlab-sandbox.measurement-lab.org",
 			want: Name{
-				Prefix:  "ndt-",
+				Service: "ndt",
 				Machine: "mlab1",
 				Site:    "lol01",
 				Project: "mlab-sandbox",
@@ -61,10 +61,10 @@ func TestName(t *testing.T) {
 			},
 		},
 		{
-			name:     "valid-v2-with-prefix-and-suffix",
+			name:     "valid-v2-with-service-and-suffix",
 			hostname: "ndt-mlab1-lol01.mlab-sandbox.measurement-lab.org-a9b8",
 			want: Name{
-				Prefix:  "ndt-",
+				Service: "ndt",
 				Machine: "mlab1",
 				Site:    "lol01",
 				Project: "mlab-sandbox",
@@ -112,43 +112,6 @@ func TestName(t *testing.T) {
 				Site:    "lol01",
 				Domain:  "measurement-lab.org",
 				Version: "v1",
-			},
-		},
-		{
-			name:     "valid-v2-with-ndt",
-			hostname: "ndt-iupui-mlab1-lol01.mlab-sandbox.measurement-lab.org",
-			want: Name{
-				Prefix:  "ndt-iupui-",
-				Machine: "mlab1",
-				Site:    "lol01",
-				Project: "mlab-sandbox",
-				Domain:  "measurement-lab.org",
-				Version: "v2",
-			},
-		},
-		{
-			name:     "valid-v2-with-ndt-short",
-			hostname: "ndt-mlab1-lol01.mlab-sandbox.measurement-lab.org",
-			want: Name{
-				Prefix:  "ndt-",
-				Machine: "mlab1",
-				Site:    "lol01",
-				Project: "mlab-sandbox",
-				Domain:  "measurement-lab.org",
-				Version: "v2",
-			},
-		},
-		{
-			name:     "valid-v2-with-ndt-short-with-suffix",
-			hostname: "ndt-mlab1-lol01.mlab-sandbox.measurement-lab.org-q44c",
-			want: Name{
-				Prefix:  "ndt-",
-				Machine: "mlab1",
-				Site:    "lol01",
-				Project: "mlab-sandbox",
-				Domain:  "measurement-lab.org",
-				Suffix:  "-q44c",
-				Version: "v2",
 			},
 		},
 		{

--- a/host/host_test.go
+++ b/host/host_test.go
@@ -27,24 +27,49 @@ func TestName(t *testing.T) {
 		},
 		{
 			name:     "valid-v2",
-			hostname: "mlab1-lol01.mlab-oti.measurement-lab.org",
+			hostname: "mlab1-lol01.mlab-sandbox.measurement-lab.org",
 			want: Name{
 				Machine: "mlab1",
 				Site:    "lol01",
-				Project: "mlab-oti",
+				Project: "mlab-sandbox",
 				Domain:  "measurement-lab.org",
 				Version: "v2",
 			},
 		},
 		{
 			name:     "valid-v2-with-suffix",
-			hostname: "mlab1-lol01.mlab-oti.measurement-lab.org-a9b8",
+			hostname: "mlab1-lol01.mlab-sandbox.measurement-lab.org-a9b8",
 			want: Name{
 				Machine: "mlab1",
 				Site:    "lol01",
-				Project: "mlab-oti",
+				Project: "mlab-sandbox",
 				Domain:  "measurement-lab.org",
-				Suffix:  "a9b8",
+				Suffix:  "-a9b8",
+				Version: "v2",
+			},
+		},
+		{
+			name:     "valid-v2-with-prefix",
+			hostname: "ndt-mlab1-lol01.mlab-sandbox.measurement-lab.org",
+			want: Name{
+				Prefix:  "ndt-",
+				Machine: "mlab1",
+				Site:    "lol01",
+				Project: "mlab-sandbox",
+				Domain:  "measurement-lab.org",
+				Version: "v2",
+			},
+		},
+		{
+			name:     "valid-v2-with-prefix-and-suffix",
+			hostname: "ndt-mlab1-lol01.mlab-sandbox.measurement-lab.org-a9b8",
+			want: Name{
+				Prefix:  "ndt-",
+				Machine: "mlab1",
+				Site:    "lol01",
+				Project: "mlab-sandbox",
+				Domain:  "measurement-lab.org",
+				Suffix:  "-a9b8",
 				Version: "v2",
 			},
 		},
@@ -60,11 +85,11 @@ func TestName(t *testing.T) {
 		},
 		{
 			name:     "valid-v2-bmc",
-			hostname: "mlab1d-lol01.mlab-oti.measurement-lab.org",
+			hostname: "mlab1d-lol01.mlab-sandbox.measurement-lab.org",
 			want: Name{
 				Machine: "mlab1d",
 				Site:    "lol01",
-				Project: "mlab-oti",
+				Project: "mlab-sandbox",
 				Domain:  "measurement-lab.org",
 				Version: "v2",
 			},
@@ -91,35 +116,38 @@ func TestName(t *testing.T) {
 		},
 		{
 			name:     "valid-v2-with-ndt",
-			hostname: "ndt-iupui-mlab1-lol01.mlab-oti.measurement-lab.org",
+			hostname: "ndt-iupui-mlab1-lol01.mlab-sandbox.measurement-lab.org",
 			want: Name{
+				Prefix:  "ndt-iupui-",
 				Machine: "mlab1",
 				Site:    "lol01",
-				Project: "mlab-oti",
+				Project: "mlab-sandbox",
 				Domain:  "measurement-lab.org",
 				Version: "v2",
 			},
 		},
 		{
 			name:     "valid-v2-with-ndt-short",
-			hostname: "ndt-mlab1-lol01.mlab-oti.measurement-lab.org",
+			hostname: "ndt-mlab1-lol01.mlab-sandbox.measurement-lab.org",
 			want: Name{
+				Prefix:  "ndt-",
 				Machine: "mlab1",
 				Site:    "lol01",
-				Project: "mlab-oti",
+				Project: "mlab-sandbox",
 				Domain:  "measurement-lab.org",
 				Version: "v2",
 			},
 		},
 		{
 			name:     "valid-v2-with-ndt-short-with-suffix",
-			hostname: "ndt-mlab1-lol01.mlab-oti.measurement-lab.org-q44c",
+			hostname: "ndt-mlab1-lol01.mlab-sandbox.measurement-lab.org-q44c",
 			want: Name{
+				Prefix:  "ndt-",
 				Machine: "mlab1",
 				Site:    "lol01",
-				Project: "mlab-oti",
+				Project: "mlab-sandbox",
 				Domain:  "measurement-lab.org",
-				Suffix:  "q44c",
+				Suffix:  "-q44c",
 				Version: "v2",
 			},
 		},
@@ -172,7 +200,7 @@ func TestName(t *testing.T) {
 				return
 			}
 			if !reflect.DeepEqual(result, test.want) {
-				t.Errorf("\nUnexpected result. Got:\n%+v\nExpected:\n%+v", result, test.want)
+				t.Errorf("\nUnexpected result. Got:\n%#v\nExpected:\n%#v", result, test.want)
 			}
 		})
 	}


### PR DESCRIPTION
Previously, the only string function returned a typical mlab hostname. This commit adds additional string functions to return various combinations of the hostname with or without prefixes and suffixes.

Additionally, this commit modifies the v2 regexp to capture and return any prefix. Previously the prefix match was a non-capturing group.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/go/158)
<!-- Reviewable:end -->
