### PR TITLE
Add SetLoadConfig method

### DIFF
--- a/cloudtest/bqfake/bqfake.go
+++ b/cloudtest/bqfake/bqfake.go
@@ -217,6 +217,9 @@ func (l Loader) Run(ctx context.Context) (bqiface.Job, error) {
 	return l.job, l.err
 }
 
+// SetLoadConfig does nothing.
+func (l Loader) SetLoadConfig(config bqiface.LoadConfig) {}
+
 // Job implements parts of bqiface.Job to allow some very basic
 // unit tests.
 type Job struct {


### PR DESCRIPTION
This PR adds a `SetLoadConfig` method for `Loader`. 

It does not return anything but it's needed to mock the [`bqiface.Loader`](https://pkg.go.dev/github.com/googleapis/google-cloud-go-testing/bigquery/bqiface#Loader) interface.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/go/166)
<!-- Reviewable:end -->
