### PR TITLE
Support third-party origins

### DIFF
--- a/host/host.go
+++ b/host/host.go
@@ -26,7 +26,7 @@ func Parse(name string) (Name, error) {
 	var parts Name
 
 	reV1 := regexp.MustCompile(`(?:[a-z-.]+)?(mlab[1-4]d?)[-.]([a-z]{3}[0-9tc]{2})\.(measurement-lab.org)$`)
-	reV2 := regexp.MustCompile(`([a-z0-9]+)?-?(mlab[1-4]d?|third)-([a-z]{3}[0-9tc]{2}|party)\.(.*?)\.(measurement-lab.org)(-[a-z0-9]{4})?$`)
+	reV2 := regexp.MustCompile(`([a-z0-9]+)?-?(mlab[1-4]d?)-([a-z]{3}[0-9tc]{2})\.(.*?)\.(measurement-lab.org)(-[a-z0-9]{4})?$`)
 
 	// Example hostnames with field counts when split by '.':
 	// v1
@@ -39,6 +39,15 @@ func Parse(name string) (Name, error) {
 	//   ndt-mlab1-lga01.mlab-oti.measurement-lab.org-d9h6 - 4 (A MIG instance with a service and random suffix)
 	//   ndt-iupui-mlab1-lga01.mlab-oti.measurement-lab.org - 4
 	//   ndt-mlab1-lga01.mlab-oti.measurement-lab.org - 4
+
+	if name == "third-party" {
+		// Unconditionally return a Name for third-party origins.
+		return Name{
+			Machine: "third",
+			Site:    "party",
+			Version: "v2",
+		}, nil
+	}
 
 	fields := strings.Split(name, ".")
 	if len(fields) < 3 || len(fields) > 6 {

--- a/host/host.go
+++ b/host/host.go
@@ -26,7 +26,7 @@ func Parse(name string) (Name, error) {
 	var parts Name
 
 	reV1 := regexp.MustCompile(`(?:[a-z-.]+)?(mlab[1-4]d?)[-.]([a-z]{3}[0-9tc]{2})\.(measurement-lab.org)$`)
-	reV2 := regexp.MustCompile(`([a-z0-9]+)?-?(mlab[1-4]d?)-([a-z]{3}[0-9tc]{2})\.(.*?)\.(measurement-lab.org)(-[a-z0-9]{4})?$`)
+	reV2 := regexp.MustCompile(`([a-z0-9]+)?-?(mlab[1-4]d?|third)-([a-z]{3}[0-9tc]{2}|party)\.(.*?)\.(measurement-lab.org)(-[a-z0-9]{4})?$`)
 
 	// Example hostnames with field counts when split by '.':
 	// v1

--- a/host/host_test.go
+++ b/host/host_test.go
@@ -96,12 +96,10 @@ func TestName(t *testing.T) {
 		},
 		{
 			name:     "valid-v2-third-party",
-			hostname: "third-party.mlab-sandbox.measurement-lab.org",
+			hostname: "third-party",
 			want: Name{
 				Machine: "third",
 				Site:    "party",
-				Project: "mlab-sandbox",
-				Domain:  "measurement-lab.org",
 				Version: "v2",
 			},
 		},
@@ -151,7 +149,7 @@ func TestName(t *testing.T) {
 		},
 		{
 			name:     "invalid-v1-third-party",
-			hostname: "third.party.measurement-lab.org",
+			hostname: "third-party.measurement-lab.org",
 			want:     Name{},
 			wantErr:  true,
 		},

--- a/host/host_test.go
+++ b/host/host_test.go
@@ -95,6 +95,17 @@ func TestName(t *testing.T) {
 			},
 		},
 		{
+			name:     "valid-v2-third-party",
+			hostname: "third-party.mlab-sandbox.measurement-lab.org",
+			want: Name{
+				Machine: "third",
+				Site:    "party",
+				Project: "mlab-sandbox",
+				Domain:  "measurement-lab.org",
+				Version: "v2",
+			},
+		},
+		{
 			name:     "valid-v1-with-ndt-flat",
 			hostname: "ndt-iupui-mlab1-lol01.measurement-lab.org",
 			want: Name{
@@ -135,6 +146,12 @@ func TestName(t *testing.T) {
 		{
 			name:     "invalid-v1-too-few-parts",
 			hostname: "lol01.measurement-lab.org",
+			want:     Name{},
+			wantErr:  true,
+		},
+		{
+			name:     "invalid-v1-third-party",
+			hostname: "third.party.measurement-lab.org",
 			want:     Name{},
 			wantErr:  true,
 		},


### PR DESCRIPTION
This change adds support for `host.Parse` to recognize the string 'third-party' in place of a hostname. This allows the jostler  (or pusher) to be used by third parties without providing a false hostname. Archives will include the string "third" in place of machine and "party" in place of site. Coincidentally, "third" and "party" have the same number of characters as a standard M-Lab machine and site name.

For example:

```
20230428T151754.656207Z-ping1-third-party-revtr-data.jsonl.gz
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/go/171)
<!-- Reviewable:end -->
