### PR TITLE
Update base travis distro to jammy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ language: go
 go:
 - 1.20
 
-dist: xenial
+dist: jammy # 22.04
 
 before_install:
 # Coverage tools


### PR DESCRIPTION
The google cloud SDK depends on python 3.8. Xenial (16.04) is very old and cannot provide this dependency. This change updates the base travis environment to one of the latest Ubuntu distributions available.

This change is meant to address build failures found in https://github.com/m-lab/go/pull/174

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/go/175)
<!-- Reviewable:end -->
