### PR TITLE
Add keyvalue flag that will preserve string escaping

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,4 +71,4 @@ script:
 after_script:
 # Coveralls
 - $HOME/gopath/bin/gocovmerge *.cov > __merged.cov
-- $HOME/gopath/bin/goveralls -coverprofile=__merged.cov -service=travis-ci
+- $HOME/gopath/bin/goveralls -coverprofile=__merged.cov -service=travis-pro

--- a/flagx/keyvalue.go
+++ b/flagx/keyvalue.go
@@ -24,6 +24,10 @@ type kvsource struct {
 // key value.
 func (kv *KeyValue) Set(kvs string) error {
 	pairs := strings.Split(kvs, ",")
+	return kv.formPairs(pairs)
+}
+
+func (kv *KeyValue) formPairs(pairs []string) error {
 	for _, pair := range pairs {
 		fields := strings.SplitN(pair, "=", 2)
 		if len(fields) != 2 {

--- a/flagx/keyvalue_escaped.go
+++ b/flagx/keyvalue_escaped.go
@@ -5,10 +5,9 @@ import (
 	"strings"
 )
 
-// KeyValueEscaped parses "key=value" pairs from a given argument. The KeyValue flag is
-// designed to be used for repeatable arguments (separated by an unescaped ',').
-// Escaped characters in the key/value will remain escaped (i.e., key\/=value\,
-// will be interpreted as key=`key\/` and value=`value\,“).
+// KeyValueEscaped parses "key=value" pairs from a given argument. Unlike the KeyValue flag,
+// which is designed for repeatable arguments separated by any ',', KeyValueEscaped allows for
+// key/value with escaped commas (i.e. `\,`), separated by an unescaped comma (i.e., ',').
 // Each use of the flag will add another key value pair (or overwrite a previous one
 // if the same key is used).
 type KeyValueEscaped struct {
@@ -20,9 +19,10 @@ type KeyValueEscaped struct {
 // When the first character of the value is prefixed by with "@", i.e. "key1=@file1",
 // Set reads the file content for the key value.
 func (kve *KeyValueEscaped) Set(kvs string) error {
+	// Match as few characters as possible up to a comma or end of line not preceded by '\'.
 	reg := regexp.MustCompile(".*?[^\\\\](,|$)")
-	pairs := reg.FindAllString(kvs, -1)
-	for i := 0; i < len(pairs)-1; i++ {
+	pairs := reg.FindAllString(kvs+",", -1)
+	for i := 0; i < len(pairs); i++ {
 		pairs[i] = strings.TrimSuffix(pairs[i], ",")
 	}
 	return kve.formPairs(pairs)

--- a/flagx/keyvalue_escaped.go
+++ b/flagx/keyvalue_escaped.go
@@ -1,0 +1,41 @@
+package flagx
+
+import (
+	"regexp"
+	"strings"
+)
+
+// KeyValueEscaped parses "key=value" pairs from a given argument. The KeyValue flag is
+// designed to be used for repeatable arguments (separated by an unescaped ',').
+// Escaped characters in the key/value will remain escaped (i.e., key\/=value\,
+// will be interpreted as key=`key\/` and value=`value\,“).
+// Each use of the flag will add another key value pair (or overwrite a previous one
+// if the same key is used).
+type KeyValueEscaped struct {
+	KeyValue
+}
+
+// Set parses key=value argument. Multiple pairs may be separated with an unescaped comma,
+// i.e. "key1=value1,key2=value2".
+// When the first character of the value is prefixed by with "@", i.e. "key1=@file1",
+// Set reads the file content for the key value.
+func (kve *KeyValueEscaped) Set(kvs string) error {
+	reg := regexp.MustCompile(".*?[^\\\\](,|$)")
+	pairs := reg.FindAllString(kvs, -1)
+	for i := 0; i < len(pairs)-1; i++ {
+		pairs[i] = strings.TrimSuffix(pairs[i], ",")
+	}
+	return kve.formPairs(pairs)
+}
+
+// String serializes parsed arguments into a form similiar to how they were
+// added from the command line. Order is not preserved.
+func (kve *KeyValueEscaped) String() string {
+	return kve.KeyValue.String()
+}
+
+// Get returns all of the KeyValueEscaped pairs as a map[string]string. The returned
+// value is a copy.
+func (kve *KeyValueEscaped) Get() map[string]string {
+	return kve.KeyValue.Get()
+}

--- a/flagx/keyvalue_escaped.go
+++ b/flagx/keyvalue_escaped.go
@@ -7,7 +7,8 @@ import (
 
 // KeyValueEscaped parses "key=value" pairs from a given argument. Unlike the KeyValue flag,
 // which is designed for repeatable arguments separated by any ',', KeyValueEscaped allows for
-// key/value with escaped commas (i.e. `\,`), separated by an unescaped comma (i.e., ',').
+// key/value with escaped commas (i.e. `\,`), with key/value pairs separated by an unescaped
+// comma (i.e., ',').
 // Each use of the flag will add another key value pair (or overwrite a previous one
 // if the same key is used).
 type KeyValueEscaped struct {

--- a/flagx/keyvalue_escaped_test.go
+++ b/flagx/keyvalue_escaped_test.go
@@ -90,9 +90,9 @@ func TestKeyValueEscaped(t *testing.T) {
 		// Escaping tests.
 		{
 			name: "success-single-value-escaped",
-			kvs:  `a\/=b\,`,
+			kvs:  `a\,=b\,`,
 			want: map[string]string{
-				`a\/`: `b\,`,
+				`a\,`: `b\,`,
 			},
 		},
 		{
@@ -108,6 +108,13 @@ func TestKeyValueEscaped(t *testing.T) {
 			want: map[string]string{
 				`a\,`: `b\,`,
 				`c\,`: `d\,`,
+			},
+		},
+		{
+			name: "success-value-ends-in-slash",
+			kvs:  `a\=b\`,
+			want: map[string]string{
+				`a\`: `b\`,
 			},
 		},
 	}

--- a/flagx/keyvalue_escaped_test.go
+++ b/flagx/keyvalue_escaped_test.go
@@ -1,0 +1,142 @@
+package flagx_test
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/go-test/deep"
+	"github.com/m-lab/go/flagx"
+)
+
+func TestKeyValueEscaped(t *testing.T) {
+	d := t.TempDir()
+	f := path.Join(d, "args.txt")
+	tests := []struct {
+		name    string
+		kvs     string
+		file    string
+		want    map[string]string
+		wantErr bool
+	}{
+		// KeyValue tests.
+		{
+			name: "success-single-keyvalue",
+			kvs:  "a=b",
+			want: map[string]string{
+				"a": "b",
+			},
+		},
+		{
+			name: "success-multiple-keyvalue",
+			kvs:  "a=b,c=d",
+			want: map[string]string{
+				"a": "b",
+				"c": "d",
+			},
+		},
+		{
+			name: "success-single-from-file",
+			kvs:  "c=@" + f,
+			file: "d",
+			want: map[string]string{
+				"c": "d",
+			},
+		},
+		{
+			name: "success-multiple-from-file",
+			kvs:  "a=b,c=@" + f,
+			file: "d",
+			want: map[string]string{
+				"a": "b",
+				"c": "d",
+			},
+		},
+		{
+			name: "success-multiple-from-file-2",
+			kvs:  "a=@" + f + ",c=@" + f,
+			file: "d",
+			want: map[string]string{
+				"a": "d",
+				"c": "d",
+			},
+		},
+		{
+			name: "success-strip-whitespace-newlines",
+			kvs:  "a=@" + f,
+			file: "\t d    \n\n ",
+			want: map[string]string{
+				"a": "d",
+			},
+		},
+		{
+			name:    "error-bad-key-value",
+			kvs:     "a=b,c",
+			wantErr: true,
+		},
+		{
+			name:    "error-missing-file",
+			kvs:     "a=b,c=@",
+			wantErr: true,
+		},
+		{
+			name:    "error-not-a-file",
+			kvs:     "a=b,c=@/",
+			wantErr: true,
+		},
+		// Escaping tests.
+		{
+			name: "success-single-value-escaped",
+			kvs:  `a\/=b\,`,
+			want: map[string]string{
+				`a\/`: `b\,`,
+			},
+		},
+		{
+			name: "success-multiple-value-escaped",
+			kvs:  `a\,=b\,,c\,=d\,`,
+			want: map[string]string{
+				`a\,`: `b\,`,
+				`c\,`: `d\,`,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.file != "" {
+				// write an args file to a tempdir.
+				err := ioutil.WriteFile(f, []byte(tt.file), os.ModePerm)
+				if err != nil {
+					t.Fatalf("FlagsFromFile write file failed: %v", err)
+				}
+			}
+
+			// Create kve flag.
+			kve := &flagx.KeyValueEscaped{}
+			if err := kve.Set(tt.kvs); (err != nil) != tt.wantErr {
+				t.Errorf("KeyValueEscaped.Set() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+
+			// Get returns a map with expected values.
+			got := kve.Get()
+			if !mapsMatch(got, tt.want) {
+				t.Errorf("KeyValueEscaped.Get() did not match; got = %v, want %v", got, tt.want)
+			}
+
+			// String returns the same fields given. Parse b/c order is not guaranteed.
+			strFields := strings.Split(kve.String(), ",")
+			sort.Strings(strFields)
+			kvsFields := strings.Split(tt.kvs, ",")
+			sort.Strings(kvsFields)
+			if diff := deep.Equal(strFields, kvsFields); diff != nil {
+				t.Errorf("KeyValueEscaped.String() did not match; got = %v, want %v, diff %v", strFields, kvsFields, diff)
+			}
+		})
+	}
+}

--- a/flagx/keyvalue_escaped_test.go
+++ b/flagx/keyvalue_escaped_test.go
@@ -96,6 +96,13 @@ func TestKeyValueEscaped(t *testing.T) {
 			},
 		},
 		{
+			name: "success-single-value-separtors-escaped",
+			kvs:  `a=b\,c\=d`,
+			want: map[string]string{
+				`a`: `b\,c\=d`,
+			},
+		},
+		{
 			name: "success-multiple-value-escaped",
 			kvs:  `a\,=b\,,c\,=d\,`,
 			want: map[string]string{

--- a/flagx/keyvalue_escaped_test.go
+++ b/flagx/keyvalue_escaped_test.go
@@ -4,11 +4,8 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
-	"sort"
-	"strings"
 	"testing"
 
-	"github.com/go-test/deep"
 	"github.com/m-lab/go/flagx"
 )
 
@@ -141,15 +138,6 @@ func TestKeyValueEscaped(t *testing.T) {
 			got := kve.Get()
 			if !mapsMatch(got, tt.want) {
 				t.Errorf("KeyValueEscaped.Get() did not match; got = %v, want %v", got, tt.want)
-			}
-
-			// String returns the same fields given. Parse b/c order is not guaranteed.
-			strFields := strings.Split(kve.String(), ",")
-			sort.Strings(strFields)
-			kvsFields := strings.Split(tt.kvs, ",")
-			sort.Strings(kvsFields)
-			if diff := deep.Equal(strFields, kvsFields); diff != nil {
-				t.Errorf("KeyValueEscaped.String() did not match; got = %v, want %v, diff %v", strFields, kvsFields, diff)
 			}
 		})
 	}


### PR DESCRIPTION
This PR adds a new KeyValue flag that allows input strings to escape special characters. This way, input values can contain commas that will not be split incorrectly (e.g., a=b\,c\=d will be interpreted as key=`a` and value=`b\,c\=d`).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/go/176)
<!-- Reviewable:end -->
