### PR TITLE
Use the default source for randomization

### DIFF
--- a/mathx/rand.go
+++ b/mathx/rand.go
@@ -5,32 +5,20 @@ import (
 	"math/rand"
 )
 
-// Random is a source of random values.
-type Random struct {
-	Src *rand.Rand // Pseudo-random source seeded with a given value.
-}
-
-// NewRandom returns a new Random that uses the provided seed to generate
-// random values.
-func NewRandom(seed int64) Random {
-	src := rand.New(rand.NewSource(seed))
-	return Random{Src: src}
-}
-
 // GetRandomInt returns a non-negative pseudo-random number in the interval [0, max).
 // It returns 0 if max <= 0.
-func (r *Random) GetRandomInt(max int) int {
+func GetRandomInt(max int) int {
 	if max <= 0 {
 		return 0
 	}
-	return r.Src.Intn(max)
+	return rand.Intn(max)
 }
 
 // GetExpDistributedInt returns a exponentially distributed number in the interval
 // [0, +math.MaxFloat64), rounded to the nearest int. Callers can adjust the rate of the
 // function through the rate parameter.
-func (r *Random) GetExpDistributedInt(rate float64) int {
-	f := r.Src.ExpFloat64() / rate
+func GetExpDistributedInt(rate float64) int {
+	f := rand.ExpFloat64() / rate
 	index := int(math.Round(f))
 	return index
 }

--- a/mathx/rand.go
+++ b/mathx/rand.go
@@ -7,6 +7,8 @@ import (
 
 // GetRandomInt returns a non-negative pseudo-random number in the interval [0, max).
 // It returns 0 if max <= 0.
+// NOTE: this function uses the default Source from the math/rand package. This source
+// is only seeded with a random value since go 1.20.
 func GetRandomInt(max int) int {
 	if max <= 0 {
 		return 0
@@ -17,6 +19,8 @@ func GetRandomInt(max int) int {
 // GetExpDistributedInt returns a exponentially distributed number in the interval
 // [0, +math.MaxFloat64), rounded to the nearest int. Callers can adjust the rate of the
 // function through the rate parameter.
+// NOTE: this function uses the default Source from the math/rand package. This source
+// is only seeded with a random value since go 1.20.
 func GetExpDistributedInt(rate float64) int {
 	f := rand.ExpFloat64() / rate
 	index := int(math.Round(f))

--- a/mathx/rand_test.go
+++ b/mathx/rand_test.go
@@ -1,10 +1,13 @@
 package mathx
 
-import "testing"
+import (
+	"math/rand"
+	"testing"
+)
 
 const seed = 1658340109320624211
 
-func TestRandom_GetRandomInt(t *testing.T) {
+func TestGetRandomInt(t *testing.T) {
 	tests := []struct {
 		name      string
 		max       int
@@ -32,14 +35,14 @@ func TestRandom_GetRandomInt(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			r := NewRandom(seed)
-			got := r.GetRandomInt(tt.max)
+			rand.Seed(seed)
+			got := GetRandomInt(tt.max)
 
 			if got != tt.expected1 {
 				t.Errorf("GetRandomInt() = %d, want %d", got, tt.expected1)
 			}
 
-			got = r.GetRandomInt(tt.max)
+			got = GetRandomInt(tt.max)
 
 			if got != tt.expected2 {
 				t.Errorf("GetRandomInt() = %d, want %d", got, tt.expected2)
@@ -48,7 +51,7 @@ func TestRandom_GetRandomInt(t *testing.T) {
 	}
 }
 
-func TestRandom_GetExpDistributedInt(t *testing.T) {
+func TestGetExpDistributedInt(t *testing.T) {
 	tests := []struct {
 		name      string
 		rate      float64
@@ -76,14 +79,14 @@ func TestRandom_GetExpDistributedInt(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			r := NewRandom(seed)
-			got := r.GetExpDistributedInt(tt.rate)
+			rand.Seed(seed)
+			got := GetExpDistributedInt(tt.rate)
 
 			if got != tt.expected1 {
 				t.Errorf("GetExpDistributedInt() = %d, want %d", got, tt.expected1)
 			}
 
-			got = r.GetExpDistributedInt(tt.rate)
+			got = GetExpDistributedInt(tt.rate)
 
 			if got != tt.expected2 {
 				t.Errorf("GetExpDistributedInt() = %d, want %d", got, tt.expected2)


### PR DESCRIPTION
This PR changes the `mathx` package to use the default `Source` from `math/rand`, which unlike [`NewSource`](https://pkg.go.dev/math/rand#NewSource), is safe for concurrent use.

Since go [1.20](https://tip.golang.org/doc/go1.20), the `math/rand` package automatically seeds the default `Source` with a random value.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/go/177)
<!-- Reviewable:end -->
