### PR TITLE
feat(host): add v3 format for dynamic dns names

### DIFF
--- a/host/host.go
+++ b/host/host.go
@@ -35,7 +35,7 @@ func Parse(name string) (Name, error) {
 	// * the same rules apply for service, iata, and project names as earlier versions.
 	// * most ASNs are 16bit numbers, but since 2007 they can be 32bit numbers, allowing up to 10 decimal digits.
 	// * machine names are 6 byte base64 encoded IPv4 addresses.
-	// * site and machine names are reversed for readability.
+	// * site name precedes machine name for readability.
 	reV3 := regexp.MustCompile(`^(?:([a-z0-9]+)-)?([a-z]{3}[0-9]{1,10})-([a-zA-Z0-9]{6})\.(.*?)\.(.*?)\.(measurement-lab.org)$`)
 
 	// Example hostnames with field counts when split by '.':

--- a/host/host.go
+++ b/host/host.go
@@ -28,7 +28,14 @@ func Parse(name string) (Name, error) {
 
 	reV1 := regexp.MustCompile(`(?:[a-z-.]+)?(mlab[1-4]d?)[-.]([a-z]{3}[0-9tc]{2})\.(measurement-lab.org)$`)
 	reV2 := regexp.MustCompile(`([a-z0-9]+)?-?(mlab[1-4]d?)-([a-z]{3}[0-9tc]{2})\.(.*?)\.(measurement-lab.org)(-[a-z0-9]{4})?$`)
-	// most ASNs are 16bit numbers, but since 2007 they can be 32bit numbers, allowing up to 10 decimal digits.
+	// The v3 naming convention is defined in:
+	// * https://docs.google.com/document/d/1XHgpX7Tbjy_c71TKsFUxb1_ax2624PB4SE9R15OoD_o/edit?#heading=h.s5vpfclyu15x
+	// The structure follows the pattern:
+	// * <service>-<IATA><ASN>-<machine>.<organization>.<project>.measurement-lab.org
+	// * the same rules apply for service, iata, and project names as earlier versions.
+	// * most ASNs are 16bit numbers, but since 2007 they can be 32bit numbers, allowing up to 10 decimal digits.
+	// * machine names are 6 byte base64 encoded IPv4 addresses.
+	// * site and machine names are reversed for readability.
 	reV3 := regexp.MustCompile(`^(?:([a-z0-9]+)-)?([a-z]{3}[0-9]{1,10})-([a-zA-Z0-9]{6})\.(.*?)\.(.*?)\.(measurement-lab.org)$`)
 
 	// Example hostnames with field counts when split by '.':
@@ -127,11 +134,8 @@ func (n Name) String() string {
 // Returns an M-lab hostname with any service name preserved
 // Example: ndt-mlab1-abc01.mlab-sandbox.measurement-lab.org
 func (n Name) StringWithService() string {
-	if n.Org != "" {
-		return fmt.Sprintf("%s-%s", n.Service, n.String())
-	}
 	if n.Service != "" {
-		return fmt.Sprintf("%s-%s-%s.%s.%s", n.Service, n.Machine, n.Site, n.Project, n.Domain)
+		return fmt.Sprintf("%s-%s", n.Service, n.String())
 	} else {
 		return n.String()
 	}

--- a/host/host_test.go
+++ b/host/host_test.go
@@ -228,7 +228,6 @@ func TestName(t *testing.T) {
 			// If we wanted an err but didn't get one, or vice versa, then fail.
 			if (err != nil) != test.wantErr {
 				t.Errorf("host.Parse() error %v, wantErr %v", err, test.wantErr)
-				t.Errorf("host.Parse() = %v", result)
 			}
 			if test.wantErr {
 				return

--- a/host/host_test.go
+++ b/host/host_test.go
@@ -165,6 +165,61 @@ func TestName(t *testing.T) {
 			want:     Name{},
 			wantErr:  true,
 		},
+		{
+			name:     "valid-v3-machine",
+			hostname: "lol12345-abcdef.mlab.sandbox.measurement-lab.org",
+			want: Name{
+				Machine: "abcdef",
+				Site:    "lol12345",
+				Org:     "mlab",
+				Project: "sandbox",
+				Domain:  "measurement-lab.org",
+				Version: "v3",
+			},
+		},
+		{
+			name:     "valid-v3-service",
+			hostname: "ndt-lol12345-abcdef.mlab.sandbox.measurement-lab.org",
+			want: Name{
+				Service: "ndt",
+				Machine: "abcdef",
+				Site:    "lol12345",
+				Org:     "mlab",
+				Project: "sandbox",
+				Domain:  "measurement-lab.org",
+				Version: "v3",
+			},
+		},
+		{
+			name:     "invalid-v3-too-long-asn-machine",
+			hostname: "lol12345678901-abcdef.mlab.sandbox.measurement-lab.org",
+			want:     Name{},
+			wantErr:  true,
+		},
+		{
+			name:     "invalid-v3-too-long-asn-service",
+			hostname: "ndt-lol12345678901-abcdef.mlab.sandbox.measurement-lab.org",
+			want:     Name{},
+			wantErr:  true,
+		},
+		{
+			name:     "invalid-v3-site-too-long",
+			hostname: "abcd12345-abcdef.mlab.sandbox.measurement-lab.org",
+			want:     Name{},
+			wantErr:  true,
+		},
+		{
+			name:     "invalid-v3-missing-service",
+			hostname: "-abc12345-abcdef.mlab.sandbox.measurement-lab.org",
+			want:     Name{},
+			wantErr:  true,
+		},
+		{
+			name:     "invalid-v3-machine-too-long",
+			hostname: "abc12345-abcdef8.mlab.sandbox.measurement-lab.org",
+			want:     Name{},
+			wantErr:  true,
+		},
 	}
 
 	for _, test := range tests {
@@ -173,6 +228,7 @@ func TestName(t *testing.T) {
 			// If we wanted an err but didn't get one, or vice versa, then fail.
 			if (err != nil) != test.wantErr {
 				t.Errorf("host.Parse() error %v, wantErr %v", err, test.wantErr)
+				t.Errorf("host.Parse() = %v", result)
 			}
 			if test.wantErr {
 				return
@@ -204,6 +260,10 @@ func TestName_String(t *testing.T) {
 		{
 			name: "ndt-mlab1-foo01.mlab-sandbox.measurement-lab.org-qf8y",
 			want: "mlab1-foo01.mlab-sandbox.measurement-lab.org",
+		},
+		{
+			name: "ndt-lol12345-abcdef.mlab.sandbox.measurement-lab.org",
+			want: "lol12345-abcdef.mlab.sandbox.measurement-lab.org",
 		},
 	}
 	for _, tt := range tests {
@@ -238,6 +298,10 @@ func TestName_StringWithService(t *testing.T) {
 			name: "ndt-mlab1-foo01.mlab-sandbox.measurement-lab.org-qf8y",
 			want: "ndt-mlab1-foo01.mlab-sandbox.measurement-lab.org",
 		},
+		{
+			name: "ndt-lol12345-abcdef.mlab.sandbox.measurement-lab.org",
+			want: "ndt-lol12345-abcdef.mlab.sandbox.measurement-lab.org",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -271,6 +335,10 @@ func TestName_StringWithSuffix(t *testing.T) {
 			name: "ndt-mlab1-foo01.mlab-sandbox.measurement-lab.org-qf8y",
 			want: "mlab1-foo01.mlab-sandbox.measurement-lab.org-qf8y",
 		},
+		{
+			name: "ndt-lol12345-abcdef.mlab.sandbox.measurement-lab.org",
+			want: "lol12345-abcdef.mlab.sandbox.measurement-lab.org",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -303,6 +371,10 @@ func TestName_StringAll(t *testing.T) {
 		{
 			name: "ndt-mlab1-foo01.mlab-sandbox.measurement-lab.org-qf8y",
 			want: "ndt-mlab1-foo01.mlab-sandbox.measurement-lab.org-qf8y",
+		},
+		{
+			name: "ndt-lol12345-abcdef.mlab.sandbox.measurement-lab.org",
+			want: "ndt-lol12345-abcdef.mlab.sandbox.measurement-lab.org",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
This change updates the go/host package by adding a new, v3 naming convention to support dynamic DNS names.

The behavior for v1 and v2 naming conventions remains unchanged.

This feature will enable development in the Locate & Heartbeat services for the new naming conventions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/go/178)
<!-- Reviewable:end -->
