### PR TITLE
fix(host): use hex encoding for machine names

### DIFF
--- a/host/host.go
+++ b/host/host.go
@@ -34,9 +34,9 @@ func Parse(name string) (Name, error) {
 	// * <service>-<IATA><ASN>-<machine>.<organization>.<project>.measurement-lab.org
 	// * the same rules apply for service, iata, and project names as earlier versions.
 	// * most ASNs are 16bit numbers, but since 2007 they can be 32bit numbers, allowing up to 10 decimal digits.
-	// * machine names are 6 byte base64 encoded IPv4 addresses.
+	// * machine names are 8 character hex encoded IPv4 addresses.
 	// * site name precedes machine name for readability.
-	reV3 := regexp.MustCompile(`^(?:([a-z0-9]+)-)?([a-z]{3}[0-9]{1,10})-([a-zA-Z0-9]{6})\.(.*?)\.(.*?)\.(measurement-lab.org)$`)
+	reV3 := regexp.MustCompile(`^(?:([a-z0-9]+)-)?([a-z]{3}[0-9]{1,10})-([a-fA-F0-9]{8})\.(.*?)\.(.*?)\.(measurement-lab.org)$`)
 
 	// Example hostnames with field counts when split by '.':
 	// v1
@@ -50,9 +50,9 @@ func Parse(name string) (Name, error) {
 	//   ndt-iupui-mlab1-lga01.mlab-oti.measurement-lab.org - 4
 	//   ndt-mlab1-lga01.mlab-oti.measurement-lab.org - 4
 	// v3
-	//   lga3356-BA6fSw.rnp.autojoin.measurement-lab.org - 5
-	//   ndt-lga3356-BA6fSw.rnp.autojoin.measurement-lab.org - 5
-	//   ndt-lga3356-BA6fSw.mlab.sandbox.measurement-lab.org - 5
+	//   lga3356-c89ffeef.rnp.autojoin.measurement-lab.org - 5
+	//   ndt-lga3356-c0a80001.rnp.autojoin.measurement-lab.org - 5
+	//   ndt-lga3356-040e9f4b.mlab.sandbox.measurement-lab.org - 5
 
 	if name == "third-party" {
 		// Unconditionally return a Name for third-party origins.

--- a/host/host_test.go
+++ b/host/host_test.go
@@ -167,9 +167,9 @@ func TestName(t *testing.T) {
 		},
 		{
 			name:     "valid-v3-machine",
-			hostname: "lol12345-abcdef.mlab.sandbox.measurement-lab.org",
+			hostname: "lol12345-abcdef01.mlab.sandbox.measurement-lab.org",
 			want: Name{
-				Machine: "abcdef",
+				Machine: "abcdef01",
 				Site:    "lol12345",
 				Org:     "mlab",
 				Project: "sandbox",
@@ -179,10 +179,10 @@ func TestName(t *testing.T) {
 		},
 		{
 			name:     "valid-v3-service",
-			hostname: "ndt-lol12345-abcdef.mlab.sandbox.measurement-lab.org",
+			hostname: "ndt-lol12345-abcdef01.mlab.sandbox.measurement-lab.org",
 			want: Name{
 				Service: "ndt",
-				Machine: "abcdef",
+				Machine: "abcdef01",
 				Site:    "lol12345",
 				Org:     "mlab",
 				Project: "sandbox",
@@ -192,31 +192,31 @@ func TestName(t *testing.T) {
 		},
 		{
 			name:     "invalid-v3-too-long-asn-machine",
-			hostname: "lol12345678901-abcdef.mlab.sandbox.measurement-lab.org",
+			hostname: "lol12345678901-abcdef01.mlab.sandbox.measurement-lab.org",
 			want:     Name{},
 			wantErr:  true,
 		},
 		{
 			name:     "invalid-v3-too-long-asn-service",
-			hostname: "ndt-lol12345678901-abcdef.mlab.sandbox.measurement-lab.org",
+			hostname: "ndt-lol12345678901-abcdef01.mlab.sandbox.measurement-lab.org",
 			want:     Name{},
 			wantErr:  true,
 		},
 		{
 			name:     "invalid-v3-site-too-long",
-			hostname: "abcd12345-abcdef.mlab.sandbox.measurement-lab.org",
+			hostname: "abcd12345-abcdef01.mlab.sandbox.measurement-lab.org",
 			want:     Name{},
 			wantErr:  true,
 		},
 		{
 			name:     "invalid-v3-missing-service",
-			hostname: "-abc12345-abcdef.mlab.sandbox.measurement-lab.org",
+			hostname: "-abc12345-abcdef01.mlab.sandbox.measurement-lab.org",
 			want:     Name{},
 			wantErr:  true,
 		},
 		{
 			name:     "invalid-v3-machine-too-long",
-			hostname: "abc12345-abcdef8.mlab.sandbox.measurement-lab.org",
+			hostname: "abc12345-abcdef789.mlab.sandbox.measurement-lab.org",
 			want:     Name{},
 			wantErr:  true,
 		},
@@ -261,8 +261,8 @@ func TestName_String(t *testing.T) {
 			want: "mlab1-foo01.mlab-sandbox.measurement-lab.org",
 		},
 		{
-			name: "ndt-lol12345-abcdef.mlab.sandbox.measurement-lab.org",
-			want: "lol12345-abcdef.mlab.sandbox.measurement-lab.org",
+			name: "ndt-lol12345-abcdef01.mlab.sandbox.measurement-lab.org",
+			want: "lol12345-abcdef01.mlab.sandbox.measurement-lab.org",
 		},
 	}
 	for _, tt := range tests {
@@ -298,8 +298,8 @@ func TestName_StringWithService(t *testing.T) {
 			want: "ndt-mlab1-foo01.mlab-sandbox.measurement-lab.org",
 		},
 		{
-			name: "ndt-lol12345-abcdef.mlab.sandbox.measurement-lab.org",
-			want: "ndt-lol12345-abcdef.mlab.sandbox.measurement-lab.org",
+			name: "ndt-lol12345-abcdef01.mlab.sandbox.measurement-lab.org",
+			want: "ndt-lol12345-abcdef01.mlab.sandbox.measurement-lab.org",
 		},
 	}
 	for _, tt := range tests {
@@ -335,8 +335,8 @@ func TestName_StringWithSuffix(t *testing.T) {
 			want: "mlab1-foo01.mlab-sandbox.measurement-lab.org-qf8y",
 		},
 		{
-			name: "ndt-lol12345-abcdef.mlab.sandbox.measurement-lab.org",
-			want: "lol12345-abcdef.mlab.sandbox.measurement-lab.org",
+			name: "ndt-lol12345-abcdef01.mlab.sandbox.measurement-lab.org",
+			want: "lol12345-abcdef01.mlab.sandbox.measurement-lab.org",
 		},
 	}
 	for _, tt := range tests {
@@ -372,8 +372,8 @@ func TestName_StringAll(t *testing.T) {
 			want: "ndt-mlab1-foo01.mlab-sandbox.measurement-lab.org-qf8y",
 		},
 		{
-			name: "ndt-lol12345-abcdef.mlab.sandbox.measurement-lab.org",
-			want: "ndt-lol12345-abcdef.mlab.sandbox.measurement-lab.org",
+			name: "ndt-lol12345-abcdef01.mlab.sandbox.measurement-lab.org",
+			want: "ndt-lol12345-abcdef01.mlab.sandbox.measurement-lab.org",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
This change fixes a bug in the v3 host naming convention. Previously, the machine name was the 6-character base64 encoded IPv4 address. However, base64 requires 64 characters and valid DNS names only allow 63 (a-zA-Z0-9-), meaning that base64 encodings will introduce additional unsupported character to DNS names. As well since DNS typically stores names in lower case only, in many cases there are only 37 characters available for valid DNS names, meaning base64 could generate name collisions (e.g. aa vs AA). This change alters the v3 convention to expect 8 characters for a hex encoded IPv4 address, which relies only on hex characters (a-zA-Z0-9) where a == A so no name collisions are possible.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/go/179)
<!-- Reviewable:end -->
