### PR TITLE
IgnoreFileError option to flagx.KeyValue

### DIFF
--- a/flagx/keyvalue.go
+++ b/flagx/keyvalue.go
@@ -12,10 +12,10 @@ import (
 type KeyValue struct {
 	pairs map[string]kvsource
 
-	// AllowMissingFile permits a file value without error even if the file is
-	// missing. If the file is missing and AllowMissingFile is true, then the
+	// IgnoreFileError permits a file value without error even if the file is
+	// missing. If the file is missing and IgnoreFileError is true, then the
 	// value is empty.
-	AllowMissingFile bool
+	IgnoreFileError bool
 }
 
 type kvsource struct {
@@ -44,7 +44,7 @@ func (kv *KeyValue) formPairs(pairs []string) error {
 		if len(fields[1]) > 0 && fields[1][0] == '@' {
 			fname := fields[1][1:]
 			b, err := os.ReadFile(fname)
-			if err != nil && !kv.AllowMissingFile {
+			if err != nil && !kv.IgnoreFileError {
 				return err
 			}
 			value := ""

--- a/flagx/keyvalue_test.go
+++ b/flagx/keyvalue_test.go
@@ -32,12 +32,12 @@ func TestKeyValue(t *testing.T) {
 	d := t.TempDir()
 	f := path.Join(d, "args.txt")
 	tests := []struct {
-		name         string
-		kvs          string
-		file         string
-		want         map[string]string
-		allowMissing bool
-		wantErr      bool
+		name        string
+		kvs         string
+		file        string
+		want        map[string]string
+		ignoreError bool
+		wantErr     bool
 	}{
 		{
 			name: "success-single-keyvalue",
@@ -89,9 +89,9 @@ func TestKeyValue(t *testing.T) {
 			},
 		},
 		{
-			name:         "success-missing-file",
-			kvs:          "a=@this-file-does-not-exist",
-			allowMissing: true,
+			name:        "success-missing-file",
+			kvs:         "a=@this-file-does-not-exist",
+			ignoreError: true,
 			want: map[string]string{
 				"a": "",
 			},
@@ -123,7 +123,7 @@ func TestKeyValue(t *testing.T) {
 			}
 
 			// Create kv flag.
-			kv := &flagx.KeyValue{AllowMissingFile: tt.allowMissing}
+			kv := &flagx.KeyValue{IgnoreFileError: tt.ignoreError}
 			if err := kv.Set(tt.kvs); (err != nil) != tt.wantErr {
 				t.Errorf("KeyValue.Set() error = %v, wantErr %v", err, tt.wantErr)
 			}


### PR DESCRIPTION
We would like the ability to specify a label read from a file even if the file is missing. e.g. `-label=key=@missingvaluefile`

This change adds backward compatible support to the `flagx.KeyValue` type to `IgnoreFileError`. Before this change, a missing file would result in an error and abort flag processing. After this change, when a `KeyValue.IgnoreFileError=true` and a file value is provided using the `@` syntax and the file name given cannot be opened for any reason (missing, permissions, other errors) the value is recorded as the empty string. When `IgnoreFileError=false` (the original and remaining default), the error opening the file will cause flag processing to fail as before.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/go/185)
<!-- Reviewable:end -->
