### PR TITLE
v3 host.Names use equivalent service and machine names

### DIFF
--- a/host/host.go
+++ b/host/host.go
@@ -222,9 +222,13 @@ func parseHostV3(f []string) (Name, error) {
 // Returns a typical M-Lab machine hostname
 // Example: mlab2-abc01.mlab-sandbox.measurement-lab.org
 func (n Name) String() string {
+	if (n == Name{}) {
+		return ""
+	}
 	switch n.Version {
 	case "v3":
-		return fmt.Sprintf("%s-%s.%s.%s.%s", n.Site, n.Machine, n.Org, n.Project, n.Domain)
+		// NOTE: v3 names include the service and are equivalent to the machine name.
+		return fmt.Sprintf("%s-%s-%s.%s.%s.%s", n.Service, n.Site, n.Machine, n.Org, n.Project, n.Domain)
 	case "v2":
 		return fmt.Sprintf("%s-%s.%s.%s", n.Machine, n.Site, n.Project, n.Domain)
 	default:
@@ -235,11 +239,11 @@ func (n Name) String() string {
 // Returns an M-lab hostname with any service name preserved
 // Example: ndt-mlab1-abc01.mlab-sandbox.measurement-lab.org
 func (n Name) StringWithService() string {
-	if n.Service != "" {
-		return fmt.Sprintf("%s-%s", n.Service, n.String())
-	} else {
+	if n.Version == "v3" || n.Service == "" {
+		// v3 names are equivalent to the machine name.
 		return n.String()
 	}
+	return fmt.Sprintf("%s-%s", n.Service, n.String())
 }
 
 // Returns an M-lab hostname with any suffix preserved

--- a/host/host_test.go
+++ b/host/host_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/m-lab/go/rtx"
+	"github.com/m-lab/go/testingx"
 )
 
 func TestName(t *testing.T) {
@@ -295,17 +295,21 @@ func TestName_String(t *testing.T) {
 		},
 		{
 			name: "ndt-lol12345-abcdef01.mlab.sandbox.measurement-lab.org",
-			want: "lol12345-abcdef01.mlab.sandbox.measurement-lab.org",
+			want: "ndt-lol12345-abcdef01.mlab.sandbox.measurement-lab.org",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			n, err := Parse(tt.name)
-			rtx.Must(err, "Failed to parse: %s", tt.name)
+			testingx.Must(t, err, "Failed to parse: %s", tt.name)
 			if got := n.String(); got != tt.want {
 				t.Errorf("Name.String() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+	// Verify an empty Name returns an empty string.
+	if (Name{}).String() != "" {
+		t.Errorf("Name.String() = %v, want ''", (Name{}).String())
 	}
 }
 
@@ -338,7 +342,7 @@ func TestName_StringWithService(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			n, err := Parse(tt.name)
-			rtx.Must(err, "Failed to parse: %s", tt.name)
+			testingx.Must(t, err, "Failed to parse: %s", tt.name)
 			if got := n.StringWithService(); got != tt.want {
 				t.Errorf("Name.StringWithService() = %v, want %v", got, tt.want)
 			}
@@ -369,13 +373,13 @@ func TestName_StringWithSuffix(t *testing.T) {
 		},
 		{
 			name: "ndt-lol12345-abcdef01.mlab.sandbox.measurement-lab.org",
-			want: "lol12345-abcdef01.mlab.sandbox.measurement-lab.org",
+			want: "ndt-lol12345-abcdef01.mlab.sandbox.measurement-lab.org",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			n, err := Parse(tt.name)
-			rtx.Must(err, "Failed to parse: %s", tt.name)
+			testingx.Must(t, err, "Failed to parse: %s", tt.name)
 			if got := n.StringWithSuffix(); got != tt.want {
 				t.Errorf("Name.StringWithSuffix() = %v, want %v", got, tt.want)
 			}
@@ -412,7 +416,7 @@ func TestName_StringAll(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			n, err := Parse(tt.name)
-			rtx.Must(err, "Failed to parse: %s", tt.name)
+			testingx.Must(t, err, "Failed to parse: %s", tt.name)
 			if got := n.StringAll(); got != tt.want {
 				t.Errorf("Name.StringAll() = %v, want %v", got, tt.want)
 			}


### PR DESCRIPTION
This change updates the `host` package v3 naming to clarify that a v3 name is both the service and machine name.

This change is to address a limitation in how Locate handles v3 names.
* See: https://github.com/m-lab/locate/issues/195 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/go/186)
<!-- Reviewable:end -->
