### PR TITLE
Add flag type to allow literal or file content values

### DIFF
--- a/flagx/stringfile.go
+++ b/flagx/stringfile.go
@@ -34,9 +34,8 @@ func (fs *StringFile) Set(v string) error {
 func (fs *StringFile) String() string {
 	if fs.file != "" {
 		return fmt.Sprintf("@%s", fs.file)
-	} else {
-		return fs.Value
 	}
+	return fs.Value
 }
 
 // Get returns the flag value.

--- a/flagx/stringfile.go
+++ b/flagx/stringfile.go
@@ -1,0 +1,45 @@
+package flagx
+
+import (
+	"fmt"
+	"os"
+)
+
+// StringFile acts like the native flag.String by storing a string from the
+// given argument. Additionally, StringFile may specify a file to read the string value from when
+// prefixed with an '@', e.g. -flag=@value.txt
+type StringFile struct {
+	Value string
+	file  string
+}
+
+// Set records the string in Value. When the first character of the parameter is
+// prefixed with "@", i.e. "@file1", Set reads the file content for the value.
+func (fs *StringFile) Set(v string) error {
+	if len(v) > 0 && v[0] == '@' {
+		fname := v[1:]
+		b, err := os.ReadFile(fname)
+		if err != nil {
+			return err
+		}
+		*fs = StringFile{Value: string(b), file: fname}
+	} else {
+		*fs = StringFile{Value: v}
+	}
+	return nil
+}
+
+// String returns the flags in a form similiar to how they were added from the
+// command line.
+func (fs *StringFile) String() string {
+	if fs.file != "" {
+		return fmt.Sprintf("@%s", fs.file)
+	} else {
+		return fs.Value
+	}
+}
+
+// Get returns the flag value.
+func (fs *StringFile) Get() string {
+	return fs.Value
+}

--- a/flagx/stringfile_test.go
+++ b/flagx/stringfile_test.go
@@ -1,0 +1,64 @@
+package flagx_test
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	"github.com/m-lab/go/flagx"
+	"github.com/m-lab/go/testingx"
+)
+
+func TestStringFile(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		useFile bool
+		wantErr bool
+	}{
+		{
+			name:    "success-string",
+			value:   "value12345",
+			useFile: false,
+		},
+		{
+			name:    "success-file",
+			value:   "1234567890abcdef",
+			useFile: true,
+		},
+		{
+			name:    "error-file",
+			value:   "@error-bad-filename",
+			useFile: false,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.value, func(t *testing.T) {
+			value := tt.value
+
+			if !tt.wantErr && tt.useFile {
+				// This is a file read - so create a file in a temp directory.
+				dir := t.TempDir()
+				name := path.Join(dir, "file.txt")
+				testingx.Must(t, os.WriteFile(name, []byte(tt.value), 0664), "failed to write test file")
+				defer os.Remove(name)
+				value = "@" + name // reset name to include directory.
+			}
+
+			fb := &flagx.StringFile{}
+			if err := fb.Set(value); (err != nil) != tt.wantErr {
+				t.Errorf("StringFile.Set() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if tt.value != fb.Get() {
+				t.Errorf("StringFile.Get() want = %q, got %q", tt.value, fb.Get())
+			}
+			if fb.String()[0] != '@' && tt.useFile {
+				t.Errorf("StringFile.String() want = @<file>, got %q", fb.String())
+			}
+		})
+	}
+}


### PR DESCRIPTION
The ndt-server (and others) typically expect the hostname to be provided as a flag. The autonode deployment does not know the hostname until after register assigns it and saves the hostname to a local file. Changes like https://github.com/m-lab/ndt-server/pull/402 added a new flag `-autocert.hostname` to read the hostname from this file using `flagx.FileBytes`. We now have a similar need for `token.machine` to require access token validation on autonodes. Rather than add another flag, ideally, we would only need one flag that allows either type of value: literal or content from a named file.

This change adds a new flag type `flagx.StringFile` which operates like the `flag.String` type while allowing the content to be read from a file using the `@<filename>` syntax. This is the same convention as used by the `KeyValue` type. This change introduces a new flag rather than modifying `FileBytes` because this convention would break backward compatibility with existing users of `FileBytes`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/go/187)
<!-- Reviewable:end -->
