### PR TITLE
Unconditioanlly adds "mlab" as value of Org field for v2 parsing

### DIFF
--- a/host/host.go
+++ b/host/host.go
@@ -138,6 +138,9 @@ func parseHostV2(f []string) (Name, error) {
 	if domain != "measurement-lab.org" {
 		return Name{}, fmt.Errorf("invalid domain: %#v", f)
 	}
+	// All V2 names represent machines that are managed by M-Lab, and join the
+	// M-Lab platform cluster. Unconditionally set Org to "mlab" rather than
+	// leaving it blank.
 	parts := Name{
 		Org:     "mlab",
 		Service: service,

--- a/host/host.go
+++ b/host/host.go
@@ -139,6 +139,7 @@ func parseHostV2(f []string) (Name, error) {
 		return Name{}, fmt.Errorf("invalid domain: %#v", f)
 	}
 	parts := Name{
+		Org:     "mlab",
 		Service: service,
 		Machine: machine,
 		Site:    site,

--- a/host/host_test.go
+++ b/host/host_test.go
@@ -29,6 +29,7 @@ func TestName(t *testing.T) {
 			name:     "valid-v2",
 			hostname: "mlab1-lol01.mlab-sandbox.measurement-lab.org",
 			want: Name{
+				Org:     "mlab",
 				Machine: "mlab1",
 				Site:    "lol01",
 				Project: "mlab-sandbox",
@@ -40,6 +41,7 @@ func TestName(t *testing.T) {
 			name:     "valid-v2-with-suffix",
 			hostname: "mlab1-lol01.mlab-sandbox.measurement-lab.org-a9b8",
 			want: Name{
+				Org:     "mlab",
 				Machine: "mlab1",
 				Site:    "lol01",
 				Project: "mlab-sandbox",
@@ -52,6 +54,7 @@ func TestName(t *testing.T) {
 			name:     "valid-v2-with-service",
 			hostname: "ndt-mlab1-lol01.mlab-sandbox.measurement-lab.org",
 			want: Name{
+				Org:     "mlab",
 				Service: "ndt",
 				Machine: "mlab1",
 				Site:    "lol01",
@@ -64,6 +67,7 @@ func TestName(t *testing.T) {
 			name:     "valid-v2-with-service-and-suffix",
 			hostname: "ndt-mlab1-lol01.mlab-sandbox.measurement-lab.org-a9b8",
 			want: Name{
+				Org:     "mlab",
 				Service: "ndt",
 				Machine: "mlab1",
 				Site:    "lol01",
@@ -92,6 +96,7 @@ func TestName(t *testing.T) {
 			name:     "valid-v2-bmc",
 			hostname: "mlab1d-lol01.mlab-sandbox.measurement-lab.org",
 			want: Name{
+				Org:     "mlab",
 				Machine: "mlab1d",
 				Site:    "lol01",
 				Project: "mlab-sandbox",


### PR DESCRIPTION
All v2 names are Org "mlab", so no reason to leave it blank

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/go/189)
<!-- Reviewable:end -->
