### PR TITLE
flagx: KeyValue ignores empty pairs

### DIFF
--- a/flagx/keyvalue.go
+++ b/flagx/keyvalue.go
@@ -21,7 +21,8 @@ type kvsource struct {
 // Set parses key=value argument. Multiple pairs may be separated with a comma,
 // i.e. "key1=value1,key2=value2". When the first character of the value is
 // prefixed by with "@", i.e. "key1=@file1", Set reads the file content for the
-// key value.
+// key value. Empty pairs are ignored, so an empty argument ("") or stray
+// commas (e.g. "key1=value1,") are a no-op rather than an error.
 func (kv *KeyValue) Set(kvs string) error {
 	pairs := strings.Split(kvs, ",")
 	return kv.formPairs(pairs)
@@ -29,6 +30,12 @@ func (kv *KeyValue) Set(kvs string) error {
 
 func (kv *KeyValue) formPairs(pairs []string) error {
 	for _, pair := range pairs {
+		// Ignore empty pairs. This makes an empty argument ("") or a stray
+		// comma a no-op instead of a "bad key/value" error, which is handy
+		// when the flag is fed from an optional environment variable.
+		if pair == "" {
+			continue
+		}
 		fields := strings.SplitN(pair, "=", 2)
 		if len(fields) != 2 {
 			return fmt.Errorf("bad key/value: %q split on '=' into %d pieces (should have been 2)", pair, len(fields))

--- a/flagx/keyvalue_test.go
+++ b/flagx/keyvalue_test.go
@@ -89,6 +89,11 @@ func TestKeyValue(t *testing.T) {
 			},
 		},
 		{
+			name: "success-empty-string-is-noop",
+			kvs:  "",
+			want: map[string]string{},
+		},
+		{
 			name:    "error-bad-key-value",
 			kvs:     "a=b,c",
 			wantErr: true,
@@ -136,6 +141,32 @@ func TestKeyValue(t *testing.T) {
 			sort.Strings(kvsFields)
 			if diff := deep.Equal(strFields, kvsFields); diff != nil {
 				t.Errorf("KeyValue.String() did not match; got = %v, want %v, diff %v", strFields, kvsFields, diff)
+			}
+		})
+	}
+}
+
+// TestKeyValueSkipsEmptyPairs verifies that empty pairs (from an empty
+// argument or stray commas) are ignored instead of producing an error.
+func TestKeyValueSkipsEmptyPairs(t *testing.T) {
+	tests := []struct {
+		name string
+		kvs  string
+		want map[string]string
+	}{
+		{name: "empty-string", kvs: "", want: map[string]string{}},
+		{name: "leading-comma", kvs: ",a=b", want: map[string]string{"a": "b"}},
+		{name: "trailing-comma", kvs: "a=b,", want: map[string]string{"a": "b"}},
+		{name: "double-comma", kvs: "a=b,,c=d", want: map[string]string{"a": "b", "c": "d"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			kv := &flagx.KeyValue{}
+			if err := kv.Set(tt.kvs); err != nil {
+				t.Fatalf("KeyValue.Set(%q) unexpected error: %v", tt.kvs, err)
+			}
+			if got := kv.Get(); !mapsMatch(got, tt.want) {
+				t.Errorf("KeyValue.Get() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
flagx.`KeyValue.Set("")` and stray commas (e.g. `a=b,`) returned a `bad key/value` error. That is awkward when the flag is fed from an optional environment variable via `ArgsFromEnv`: an empty value crashes programs that wrap it in `rtx.Must`. This makes empty pairs a no-op instead.

Non-empty malformed pairs (e.g. `a=b,c`) still error. Adds tests for empty string, leading/trailing/double commas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/go/205)
<!-- Reviewable:end -->
